### PR TITLE
Add missing sys/time.h. Fixes build on MacOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build*
+.vscode/

--- a/src/adksys.h
+++ b/src/adksys.h
@@ -6,6 +6,8 @@
 #if !defined(ADKSYS_H_)
 #define ADKSYS_H_
 
+#include <sys/time.h> /* struct timeval */
+
 int adksys_get_libraries(char ***libraries, int *libraries_size, int *libnames_need_free);
 int adksys_hostlist(char ***out_hostlist_array, int *out_num_hosts, char **out_name_buffer, int all_ranks);
 int adksys_jobsize(int *size);


### PR DESCRIPTION
`sys/time.h` for `struct timeval` was missing in adksys.h.
Also adds .gitignore.