### PR TITLE
Add feature test macro for long long support

### DIFF
--- a/include/adiak.h
+++ b/include/adiak.h
@@ -16,6 +16,8 @@ extern "C" {
 #define ADIAK_MINOR_VERSION 3
 #define ADIAK_POINT_VERSION 0
 
+#define ADIAK_HAVE_LONGLONG 1
+
 // ADIAK DATA CATEGORIES 
 // Please treat values through 1000 as reserved. 1001 onward can be used as
 // custom categories


### PR DESCRIPTION
Add a feature test macro to let codes test for long long support. Makes testing for features more direct than using ADIAK_VERSION and ADIAK_MINOR_VERSION, especially since they are inconsistent between 0.1 and 0.2+.  