### PR TITLE
Added Kokkos metadata callback

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 blt_add_library( NAME adiak
                  HEADERS ${adiak_public_headers}
-                 SOURCES adiak.c ${adiak_sys_sources} ${adiak_mpi_source}
+                 SOURCES adiak.c adiak_kokkos.cpp ${adiak_sys_sources} ${adiak_mpi_source}
                  DEPENDS_ON ${adiak_mpi_depends})
 
 install(FILES

--- a/src/adiak_kokkos.cpp
+++ b/src/adiak_kokkos.cpp
@@ -1,0 +1,4 @@
+#include <adiak.hpp>
+extern "C" void kokkosp_declare_metadata(const char* key, const char* value) {
+  adiak::value(key, value);
+}


### PR DESCRIPTION
Intent: we want the metadata Kokkos declares to be captured by Spot.

So this just adds such a callback to Adiak, declaring our metadata as raw key-value.