### PR TITLE
Resolve some unused parameter issues that break client code that #include's adiak.hpp

### DIFF
--- a/include/adiak_internal.hpp
+++ b/include/adiak_internal.hpp
@@ -289,9 +289,9 @@ namespace adiak
 
       template <typename T>
       struct set_tuple_type<T, 0> {
-         static void settype(adiak_datatype_t **dtypes) {
+         static void settype(adiak_datatype_t **/*dtypes*/) {
          }
-         static bool setvalue(T &c, adiak_value_t *values, adiak_datatype_t *dtype) {
+         static bool setvalue(T &/*c*/, adiak_value_t */*values*/, adiak_datatype_t */*dtype*/) {
             return true;
          }
       };

--- a/src/adiak.c
+++ b/src/adiak.c
@@ -993,9 +993,9 @@ int adiak_hostlist()
 {
    char **hostlist_array = NULL;
    int num_hosts = 0, result = -1;
-   char *name_buffer = NULL;
 
 #if defined(USE_MPI)
+   char *name_buffer = NULL;
    if (adiak_config->use_mpi)
       result = adksys_hostlist(&hostlist_array, &num_hosts, &name_buffer, adiak_config->report_on_all_ranks);
 #endif
@@ -1012,9 +1012,9 @@ int adiak_num_hosts()
 {
    char **hostlist_array = NULL;
    int num_hosts = 0, result = -1;
-   char *name_buffer = NULL;
 
 #if defined(USE_MPI)
+   char *name_buffer = NULL;
    if (adiak_config->use_mpi)
       result = adksys_hostlist(&hostlist_array, &num_hosts, &name_buffer, adiak_config->report_on_all_ranks);
 #endif
@@ -1029,9 +1029,10 @@ int adiak_num_hosts()
 
 int adiak_job_size()
 {
-   int result = -1, size = 1;
+   int size = 1;
 
 #if defined(USE_MPI)
+   int result = -1;
    if (adiak_config->use_mpi)
       result = adksys_jobsize(&size);
    if (result == -1)

--- a/tests/testapp.c
+++ b/tests/testapp.c
@@ -79,7 +79,13 @@ void dowork(struct timeval start)
    if (result != 0) printf("return: %d\n\n", result);
 }
 
-int main(int argc, char *argv[])
+int main(
+#if defined(USE_MPI)
+         int argc, char *argv[]
+#else
+         int UNUSED(argc), char **UNUSED(argv)
+#endif
+         )
 {
 #if defined(USE_MPI)
    MPI_Comm world = MPI_COMM_WORLD;

--- a/tests/testapp.cpp
+++ b/tests/testapp.cpp
@@ -12,10 +12,13 @@
 
 using namespace std;
 
-void dowork(struct timeval start)
+void dowork(struct timeval
+#if defined(USE_MPI)
+            start
+#endif
+  )
 {
    bool result;
-   struct timeval end;
 
    vector<double> grid;
    grid.push_back(4.5);
@@ -135,7 +138,8 @@ void dowork(struct timeval start)
    if (!result) printf("return: %d\n\n", result);
 #endif
    
-/*   gettimeofday(&end, NULL);
+/* struct timeval end;
+   gettimeofday(&end, NULL);
    result = adiak::value("computetime", &start, &end);
    if (!result) printf("return: %d\n\n", result);*/
    
@@ -147,7 +151,13 @@ void dowork(struct timeval start)
    if (!result) printf("return: %d\n\n", result);   
 }
 
-int main(int argc, char *argv[])
+int main(
+#if defined(USE_MPI)
+  int argc, char *argv[]
+#else
+  int, char **
+#endif
+  )
 {
 #if defined(USE_MPI)
    MPI_Comm world = MPI_COMM_WORLD;

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -9,6 +9,13 @@
 #define XSTR(S) #S
 #define STR(S) XSTR(S)
 
+#ifdef __GNUC__
+#define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#define UNUSED(x) UNUSED_ ## x
+#endif
+
+
 static void print_value(adiak_value_t *val, adiak_datatype_t *t)
 {
    if (!t)
@@ -118,14 +125,14 @@ static void print_value(adiak_value_t *val, adiak_datatype_t *t)
    }
 }
 
-static void print_nameval(const char *name, int category, const char *subcategory, adiak_value_t *value, adiak_datatype_t *t, void *opaque_value)
+static void print_nameval(const char *name, int UNUSED(category), const char *UNUSED(subcategory), adiak_value_t *value, adiak_datatype_t *t, void *UNUSED(opaque_value))
 {
    printf("%s - %s: ", STR(TOOLNAME), name);
    print_value(value, t);
    printf("\n");
 }
 
-static void print_on_flush(const char *name, int category, const char *subcategory, adiak_value_t *value, adiak_datatype_t *t, void *opaque_value)
+static void print_on_flush(const char *name, int UNUSED(category), const char *UNUSED(subcategory), adiak_value_t *UNUSED(value), adiak_datatype_t *UNUSED(t), void *UNUSED(opaque_value))
 {
    if (strcmp(name, "fini") != 0)
       return;


### PR DESCRIPTION
I am part of a project that's using adiak. The clang build used -Werror and -Wunused-parameter. This causes the compiler to fail while processing the adiak header file. Clang expects unused parameters not to be named.