### PR TITLE
Fix cmake exports and use cmake export prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR lib)
 endif()
 
+set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
 
 if (DEFINED BLT_SOURCE_DIR)
     # Support having a shared BLT outside of the repository if given a BLT_SOURCE_DIR

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,11 +2,9 @@
 
 set_and_check(adiak_INCLUDE_DIR "@PACKAGE_adiak_INSTALL_INCLUDE_DIR@")
 
-if (NOT TARGET adiak)
-  include(${CMAKE_CURRENT_LIST_DIR}/adiak-targets.cmake)
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/adiak-targets.cmake)
 
 set(adiak_INCLUDE_DIRS ${adiak_INCLUDE_DIR})
-set(adiak_LIBRARIES adiak)
+set(adiak_LIBRARIES adiak::adiak)
 
 check_required_components(adiak)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,14 +28,9 @@ install(FILES
         DESTINATION include)
 
 install(TARGETS
-  adiak
+  adiak ${adiak_mpi_depends}
   EXPORT adiak-targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-if (MPI_FOUND)
-  set_target_properties(mpi PROPERTIES EXPORT_NAME adiak::mpi)
-  install(TARGETS mpi EXPORT adiak-targets)
-endif()
-
-install(EXPORT adiak-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/adiak)
+install(EXPORT adiak-targets NAMESPACE adiak:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/adiak)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(.)
+  include_directories(.)
 include_directories(../include)
 
 set(adiak_public_headers ../include/adiak.h ../include/adiak.hpp ../include/adiak_internal.hpp ../include/adiak_tool.h)
@@ -32,5 +32,10 @@ install(TARGETS
   EXPORT adiak-targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if (MPI_FOUND)
+  set_target_properties(mpi PROPERTIES EXPORT_NAME adiak::mpi)
+  install(TARGETS mpi EXPORT adiak-targets)
+endif()
 
 install(EXPORT adiak-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/adiak)


### PR DESCRIPTION
This change

- Adds adiak dependencies like `mpi` to the cmake export list. This fixes link failures in projects using CMake `find_package(adiak)`.
- Moves all cmake exports into the `adiak::` namespace, adhering to modern CMake style.

Dependent projects using CMake `find_package(adiak)` to import Adiak must now use `adiak::adiak` as link target instead of `adiak`. No change is needed if they use the `${adiak_LIBRARIES}` variable.