### PR TITLE
CMake adiak::adiak target includes headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,9 @@ blt_add_library( NAME adiak
                  HEADERS ${adiak_public_headers}
                  SOURCES adiak.c ${adiak_sys_sources} ${adiak_mpi_source}
                  DEPENDS_ON ${adiak_mpi_depends})
+target_include_directories(adiak
+  PUBLIC
+  "$<INSTALL_INTERFACE:include>")
 
 install(FILES
         ${adiak_public_headers}


### PR DESCRIPTION
this additional line ensures that when
downstream users do
target_link_libraries(my-app PUBLIC adiak::adiak)
then their app will include the installed
headers directory for Adiak