### PR TITLE
include_directories fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-  include_directories(.)
-include_directories(../include)
-
 set(adiak_public_headers ../include/adiak.h ../include/adiak.hpp ../include/adiak_internal.hpp ../include/adiak_tool.h)
 
 if (APPLE)
@@ -24,6 +21,7 @@ blt_add_library( NAME adiak
                  DEPENDS_ON ${adiak_mpi_depends})
 target_include_directories(adiak
   PUBLIC
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 
 install(FILES


### PR DESCRIPTION
1. specifies `BUILD_INTERFACE` for `target_include_directories` to enable usage of Adiak via `add_subdirectory`
2. eliminates unused `include_directories(.)`