### PR TITLE
Add more MPI information

### DIFF
--- a/docs/sphinx/ApplicationAPI.rst
+++ b/docs/sphinx/ApplicationAPI.rst
@@ -17,45 +17,52 @@ Adiak's implicit routines register commonly used name/value pairs about a
 job's execution environment under common names. The table below lists
 the available implicit routines, and the name/value pair they register.
 
-+----------------------------+----------------+-------------------------------------+
-| Function                   | Name           | Description                         |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`adiakversion`   | adiakversion   | Adiak library version               |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`user`           | user           | Name of user running the job        |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`uid`            | uid            | User ID of user running the job     |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`launchdate`     | launchdate     | Day/time of job launch (UNIX time)  |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`launchday`      | launchday      | Day of job launch (UNIX time)       |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`executable`     | executable     | Executable name                     |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`executablepath` | executablepath | Full path to the program executable |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`workdir`        | workdir        | Working directory for the job       |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`libraries`      | libraries      | Set of loaded shared libraries      |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`cmdline`        | cmdline        | Program command line parameters     |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`hostname`       | hostname       | Network host name                   |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`clustername`    | clustername    | Cluster name (hostname w/o numbers) |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`walltime`       | walltime       | Process walltime                    |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`cputime`        | cputime        | Process CPU time                    |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`systime`        | systime        | Process system time                 |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`jobsize`        | jobsize        | MPI job size                        |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`numhosts`       | numhosts       | Number of distinct nodes in MPI job |
-+----------------------------+----------------+-------------------------------------+
-| :cpp:func:`hostlist`       | hostlist       | List of distinct nodes in MPI job   |
-+----------------------------+----------------+-------------------------------------+
++---------------------------------+----------------+-------------------------------------+
+| Function                        | Name           | Description                         |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`adiakversion`        | adiakversion   | Adiak library version               |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`user`                | user           | Name of user running the job        |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`uid`                 | uid            | User ID of user running the job     |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`launchdate`          | launchdate     | Day/time of job launch (UNIX time)  |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`launchday`           | launchday      | Day of job launch (UNIX time)       |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`executable`          | executable     | Executable name                     |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`executablepath`      | executablepath | Full path to the program executable |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`workdir`             | workdir        | Working directory for the job       |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`libraries`           | libraries      | Set of loaded shared libraries      |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`cmdline`             | cmdline        | Program command line parameters     |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`hostname`            | hostname       | Network host name                   |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`clustername`         | clustername    | Cluster name (hostname w/o numbers) |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`walltime`            | walltime       | Process walltime                    |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`cputime`             | cputime        | Process CPU time                    |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`systime`             | systime        | Process system time                 |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`jobsize`             | jobsize        | MPI job size                        |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`numhosts`            | numhosts       | Number of distinct nodes in MPI job |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`hostlist`            | hostlist       | List of distinct nodes in MPI job   |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`mpi_version`         | mpi_version    | MPI standard version                |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`mpi_library`         | mpi_library    | MPI_Get_library_version() output    |
++---------------------------------+----------------+-------------------------------------+
+| :cpp:func:`mpi_library_version` | mpi_library_   | MPI library version and vendor      |
+|                                 | vendor/version |                                     |
++---------------------------------+----------------+-------------------------------------+
 
 The catchall function :cpp:func:`adiak_collect_all` function collects all of the
 common name/value pairs except walltime, systime, and cputime.

--- a/include/adiak.h
+++ b/include/adiak.h
@@ -362,7 +362,11 @@ int adiak_hostlist();
 int adiak_num_hosts();
 /** \brief Makes a 'mpi_version' name/val with the MPI standard version */
 int adiak_mpiversion();
-/** \brief Makes a 'mpi_library' name/val with the MPI library version */
+/** \brief Makes a 'mpi_library' name/val with MPI library info
+ *
+ * Returns the information given by MPI_Get_library_version(). Note that
+ * this can be a long, multi-line string.
+ */
 int adiak_mpilibrary();
 
 /** \brief Collect all available built-in Adiak name/value pairs

--- a/include/adiak.h
+++ b/include/adiak.h
@@ -364,11 +364,20 @@ int adiak_num_hosts();
 int adiak_mpi_version();
 /** \brief Makes a 'mpi_library' name/val with MPI library info
  *
- * Returns the information given by MPI_Get_library_version(). Note that
- * this can be a long, multi-line string.
+ * Returns the information given by MPI_Get_library_version(). The output
+ * is different for each MPI library implementation, and can be a long,
+ * multi-line string.
  */
 int adiak_mpi_library();
-
+/** \brief Reports MPI library version and vendor information
+ *
+ * Makes mpi_library_version and mpi_library_vendor name/value pairs
+ * with the MPI library version and vendor. Uses the information
+ * provided by \a MPI_Get_library_version(), but parses out the library
+ * version and vendor. Currently this works for
+ * CRAY MPICH, IBM Spectrum MPI, Open MPI, MVAPICH2, and MPICH.
+ */
+int adiak_mpi_library_version();
 /** \brief Collect all available built-in Adiak name/value pairs
  *
  * This shortcut invokes all of the pre-defined routines that collect common

--- a/include/adiak.h
+++ b/include/adiak.h
@@ -372,9 +372,9 @@ int adiak_mpi_library();
 /** \brief Reports MPI library version and vendor information
  *
  * Makes mpi_library_version and mpi_library_vendor name/value pairs
- * with the MPI library version and vendor. Uses the information
- * provided by \a MPI_Get_library_version(), but parses out the library
- * version and vendor. Currently this works for
+ * with the MPI library version and vendor. It parses out the version
+ * and vendor information from the string provided by
+ * \a MPI_Get_library_version(). Currently this works for
  * CRAY MPICH, IBM Spectrum MPI, Open MPI, MVAPICH2, and MPICH.
  */
 int adiak_mpi_library_version();

--- a/include/adiak.h
+++ b/include/adiak.h
@@ -361,13 +361,13 @@ int adiak_hostlist();
  */
 int adiak_num_hosts();
 /** \brief Makes a 'mpi_version' name/val with the MPI standard version */
-int adiak_mpiversion();
+int adiak_mpi_version();
 /** \brief Makes a 'mpi_library' name/val with MPI library info
  *
  * Returns the information given by MPI_Get_library_version(). Note that
  * this can be a long, multi-line string.
  */
-int adiak_mpilibrary();
+int adiak_mpi_library();
 
 /** \brief Collect all available built-in Adiak name/value pairs
  *

--- a/include/adiak.h
+++ b/include/adiak.h
@@ -360,6 +360,10 @@ int adiak_hostlist();
  * ranks in the communicator provided to \ref adiak_init.
  */
 int adiak_num_hosts();
+/** \brief Makes a 'mpi_version' name/val with the MPI standard version */
+int adiak_mpiversion();
+/** \brief Makes a 'mpi_library' name/val with the MPI library version */
+int adiak_mpilibrary();
 
 /** \brief Collect all available built-in Adiak name/value pairs
  *

--- a/include/adiak.hpp
+++ b/include/adiak.hpp
@@ -269,14 +269,19 @@ namespace adiak
       return adiak_num_hosts() == 0;
    }
 
-   /// \copydoc adiak_mpiversion
+   /// \copydoc adiak_mpi_version
    inline bool mpi_version() {
       return adiak_mpi_version() == 0;
    }
 
-   /// \copydoc adiak_mpilibrary
+   /// \copydoc adiak_mpi_library
    inline bool mpi_library() {
       return adiak_mpi_library() == 0;
+   }
+
+   /// \copydoc adiak_mpi_library_version
+   inline bool mpi_library_version() {
+      return adiak_mpi_library_version() == 0;
    }
 
    /// \copydoc adiak_flush

--- a/include/adiak.hpp
+++ b/include/adiak.hpp
@@ -269,6 +269,16 @@ namespace adiak
       return adiak_num_hosts() == 0;
    }
 
+   /// \copydoc adiak_mpiversion
+   inline bool mpiversion() {
+      return adiak_mpiversion() == 0;
+   }
+
+   /// \copydoc adiak_mpilibrary
+   inline bool mpilibrary() {
+      return adiak_mpilibrary() == 0;
+   }
+
    /// \copydoc adiak_flush
    inline bool flush(std::string output) {
       return adiak_flush(output.c_str()) == 0;

--- a/include/adiak.hpp
+++ b/include/adiak.hpp
@@ -270,13 +270,13 @@ namespace adiak
    }
 
    /// \copydoc adiak_mpiversion
-   inline bool mpiversion() {
-      return adiak_mpiversion() == 0;
+   inline bool mpi_version() {
+      return adiak_mpi_version() == 0;
    }
 
    /// \copydoc adiak_mpilibrary
-   inline bool mpilibrary() {
-      return adiak_mpilibrary() == 0;
+   inline bool mpi_library() {
+      return adiak_mpi_library() == 0;
    }
 
    /// \copydoc adiak_flush

--- a/src/adiak.c
+++ b/src/adiak.c
@@ -1045,10 +1045,11 @@ int adiak_job_size()
 
 #if defined(USE_MPI)
    int result = -1;
-   if (adiak_config->use_mpi)
+   if (adiak_config->use_mpi) {
       result = adksys_jobsize(&size);
-   if (result == -1)
-      return -1;
+      if (result == -1)
+         return -1;
+   }
 #endif
    return adiak_namevalue("jobsize", adiak_general, "mpi", "%u", size);
 }
@@ -1097,30 +1098,30 @@ int adiak_cputime()
    return 0;
 }
 
-int adiak_mpiversion()
+int adiak_mpi_version()
 {
 #if defined(USE_MPI)
    char buf[16];
    int result = -1;
    if (adiak_config->use_mpi)
-      result = adksys_mpiversion(buf, 16);
+      result = adksys_mpi_version(buf, 16);
    if (result == -1)
       return -1;
-   return adiak_namevalue("mpiversion", adiak_general, "mpi", "%v", buf);
+   return adiak_namevalue("mpi_version", adiak_general, "mpi", "%v", buf);
 #endif
    return -1;
 }
 
-int adiak_mpilibrary()
+int adiak_mpi_library()
 {
 #if defined(USE_MPI)
    char buf[2048];
    int result = -1;
    if (adiak_config->use_mpi)
-      result = adksys_mpilibrary(buf, 2048);
+      result = adksys_mpi_library(buf, 2048);
    if (result == -1)
       return -1;
-   return adiak_namevalue("mpilibrary", adiak_general, "mpi", "%s", buf);
+   return adiak_namevalue("mpi_library", adiak_general, "mpi", "%s", buf);
 #endif
    return -1;
 }
@@ -1174,15 +1175,15 @@ int adiak_collect_all()
    ret = adiak_hostlist();
    if (ret == 0)
       ++count;
-   ret = adiak_mpiversion();
+   ret = adiak_mpi_version();
    if (ret == 0)
       ++count;
 #if 0
    /*
-    *   Danger: adiak_mpilibrary() can produce strings with newlines, which is
+    *   Danger: adiak_mpi_library() can produce strings with newlines, which is
     * only supported in not-yet-released Caliper/caliperreader versions (v2.11+)
     */
-   ret = adiak_mpilibrary();
+   ret = adiak_mpi_library();
    if (ret == 0)
       ++count;
 #endif

--- a/src/adiak.c
+++ b/src/adiak.c
@@ -1126,6 +1126,22 @@ int adiak_mpi_library()
    return -1;
 }
 
+int adiak_mpi_library_version()
+{
+#if defined(USE_MPI)
+   char vendor[80];
+   char version[40];
+   int result = -1;
+   if (adiak_config->use_mpi)
+      result = adksys_mpi_library_version(vendor, 80, version, 40);
+   if (result == -1)
+      return -1;
+   adiak_namevalue("mpi_library_vendor", adiak_general, "mpi", "%s", vendor);
+   adiak_namevalue("mpi_library_version", adiak_general, "mpi", "%v", version);
+#endif
+   return -1;
+}
+
 int adiak_collect_all()
 {
    int count = 0;
@@ -1178,15 +1194,9 @@ int adiak_collect_all()
    ret = adiak_mpi_version();
    if (ret == 0)
       ++count;
-#if 0
-   /*
-    *   Danger: adiak_mpi_library() can produce strings with newlines, which is
-    * only supported in not-yet-released Caliper/caliperreader versions (v2.11+)
-    */
-   ret = adiak_mpi_library();
+   ret = adiak_mpi_library_version();
    if (ret == 0)
       ++count;
-#endif
 
    return (count > 0 ? 0 : -1);
 }

--- a/src/adiak.c
+++ b/src/adiak.c
@@ -1097,6 +1097,34 @@ int adiak_cputime()
    return 0;
 }
 
+int adiak_mpiversion()
+{
+#if defined(USE_MPI)
+   char buf[16];
+   int result = -1;
+   if (adiak_config->use_mpi)
+      result = adksys_mpiversion(buf, 16);
+   if (result == -1)
+      return -1;
+   return adiak_namevalue("mpiversion", adiak_general, "mpi", "%v", buf);
+#endif
+   return -1;
+}
+
+int adiak_mpilibrary()
+{
+#if defined(USE_MPI)
+   char buf[2048];
+   int result = -1;
+   if (adiak_config->use_mpi)
+      result = adksys_mpilibrary(buf, 2048);
+   if (result == -1)
+      return -1;
+   return adiak_namevalue("mpilibrary", adiak_general, "mpi", "%s", buf);
+#endif
+   return -1;
+}
+
 int adiak_collect_all()
 {
    int count = 0;
@@ -1146,6 +1174,18 @@ int adiak_collect_all()
    ret = adiak_hostlist();
    if (ret == 0)
       ++count;
+   ret = adiak_mpiversion();
+   if (ret == 0)
+      ++count;
+#if 0
+   /*
+    *   Danger: adiak_mpilibrary() can produce strings with newlines, which is
+    * only supported in not-yet-released Caliper/caliperreader versions (v2.11+)
+    */
+   ret = adiak_mpilibrary();
+   if (ret == 0)
+      ++count;
+#endif
 
    return (count > 0 ? 0 : -1);
 }

--- a/src/adksys.h
+++ b/src/adksys.h
@@ -25,5 +25,6 @@ int adksys_get_cwd(char *cwd, size_t max_size);
 void *adksys_get_public_adiak_symbol();
 int adksys_mpi_version(char* output, size_t output_size);
 int adksys_mpi_library(char* output, size_t output_size);
+int adksys_mpi_library_version(char* vendor, size_t vendor_len, char* version, size_t version_len);
 
 #endif

--- a/src/adksys.h
+++ b/src/adksys.h
@@ -23,7 +23,7 @@ int adksys_get_names(char **uid, char **user);
 int adksys_mpi_initialized();
 int adksys_get_cwd(char *cwd, size_t max_size);
 void *adksys_get_public_adiak_symbol();
-int adksys_mpiversion(char* output, size_t output_size);
-int adksys_mpilibrary(char* output, size_t output_size);
+int adksys_mpi_version(char* output, size_t output_size);
+int adksys_mpi_library(char* output, size_t output_size);
 
 #endif

--- a/src/adksys.h
+++ b/src/adksys.h
@@ -23,5 +23,7 @@ int adksys_get_names(char **uid, char **user);
 int adksys_mpi_initialized();
 int adksys_get_cwd(char *cwd, size_t max_size);
 void *adksys_get_public_adiak_symbol();
+int adksys_mpiversion(char* output, size_t output_size);
+int adksys_mpilibrary(char* output, size_t output_size);
 
 #endif

--- a/src/adksys_mpi.c
+++ b/src/adksys_mpi.c
@@ -189,13 +189,13 @@ int adksys_jobsize(int *size)
    return 0;
 }
 
-int adksys_mpiversion(char* output, size_t output_size)
+int adksys_mpi_version(char* output, size_t output_size)
 {
    int ret = snprintf(output, output_size, "%d.%d", MPI_VERSION, MPI_SUBVERSION);
    return (ret >= 0 && ((size_t) ret) < output_size ? 0 : -1);
 }
 
-int adksys_mpilibrary(char* output, size_t output_size)
+int adksys_mpi_library(char* output, size_t output_size)
 {
    memset(output, 0, output_size);
    char buf[MPI_MAX_LIBRARY_VERSION_STRING];

--- a/src/adksys_mpi.c
+++ b/src/adksys_mpi.c
@@ -6,6 +6,7 @@
 #include <mpi.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include "adksys.h"
 
 #if !defined(USE_MPI)
@@ -185,6 +186,25 @@ int adksys_jobsize(int *size)
    result = MPI_Comm_size(adiak_communicator, size);
    if (result != MPI_SUCCESS)
       return -1;
+   return 0;
+}
+
+int adksys_mpiversion(char* output, size_t output_size)
+{
+   int ret = snprintf(output, output_size, "%d.%d", MPI_VERSION, MPI_SUBVERSION);
+   return (ret >= 0 && ((size_t) ret) < output_size ? 0 : -1);
+}
+
+int adksys_mpilibrary(char* output, size_t output_size)
+{
+   memset(output, 0, output_size);
+   char buf[MPI_MAX_LIBRARY_VERSION_STRING];
+   int len = MPI_MAX_LIBRARY_VERSION_STRING;
+   int err = MPI_Get_library_version(buf, &len);
+   if (err != MPI_SUCCESS || ((size_t) len) > output_size)
+      return -1;
+   strncpy(output, buf, output_size);
+   output[output_size-1] = '\0';
    return 0;
 }
 

--- a/src/adksys_mpi.c
+++ b/src/adksys_mpi.c
@@ -21,10 +21,10 @@ static int hostname_color(char *str, int index)
 {
    int hash = 5381;
    int c;
-   
+
    while ((c = *str++))
       hash = ((hash << 5) + hash) + (c^index); /* hash * 33 + c */
-   
+
    return hash;
 }
 
@@ -44,12 +44,12 @@ static int get_unique_host(char *name, int global_rank)
       color = hostname_color(name, index++);
       if (color < 0)
          color *= -1;
-      
+
       result = MPI_Comm_split(oldcomm, color, global_rank, &newcomm);
       if (result != MPI_SUCCESS) {
          goto error;
       }
-      
+
       if (set_oldcomm) {
          MPI_Comm_free(&oldcomm);
          oldcomm = MPI_COMM_NULL;
@@ -57,7 +57,7 @@ static int get_unique_host(char *name, int global_rank)
 
       MPI_Comm_rank(newcomm, &rank);
       MPI_Comm_size(newcomm, &size);
-      
+
       if (rank == 0)
          strncpy(oname, name, MAX_HOSTNAME_LEN);
       result = MPI_Bcast(oname, MAX_HOSTNAME_LEN, MPI_CHAR, 0, newcomm);
@@ -75,11 +75,11 @@ static int get_unique_host(char *name, int global_rank)
       if (global_str_match) {
          break;
       }
-      
+
       set_oldcomm = 1;
       oldcomm = newcomm;
    }
-   
+
    err_ret = 0;
   error:
 
@@ -87,7 +87,7 @@ static int get_unique_host(char *name, int global_rank)
       MPI_Comm_free(&oldcomm);
    if (newcomm != adiak_communicator && newcomm != MPI_COMM_NULL)
       MPI_Comm_free(&newcomm);
-   
+
    if (err_ret == -1)
       return err_ret;
    return (rank == 0 ? 1 : 0);
@@ -131,7 +131,7 @@ static int gethostlist(char **hostlist, int *num_hosts, int *max_hostlen, int al
    MPI_Comm_free(&hostcomm);
 
    MPI_Bcast(max_hostlen, 1, MPI_INT, 0, adiak_communicator);
-   MPI_Bcast(num_hosts, 1, MPI_INT, 0, adiak_communicator);   
+   MPI_Bcast(num_hosts, 1, MPI_INT, 0, adiak_communicator);
    hostlist_size = (*max_hostlen) * (*num_hosts);
    if (!(*hostlist))
        *hostlist = (char *) malloc(hostlist_size);
@@ -150,7 +150,7 @@ int adksys_hostlist(char ***out_hostlist_array, int *out_num_hosts, char **out_n
 
    if (had_error)
       return -1;
-   
+
    if (hostlist)
       goto done;
 
@@ -163,7 +163,7 @@ int adksys_hostlist(char ***out_hostlist_array, int *out_num_hosts, char **out_n
 
    hostlist_array = malloc(sizeof(char *) * num_hosts);
    for (i = 0; i < num_hosts; i++)
-      hostlist_array[i] = hostlist + (i * max_hostlen);      
+      hostlist_array[i] = hostlist + (i * max_hostlen);
 
   done:
    *out_hostlist_array = hostlist_array;
@@ -206,6 +206,109 @@ int adksys_mpi_library(char* output, size_t output_size)
    strncpy(output, buf, output_size);
    output[output_size-1] = '\0';
    return 0;
+}
+
+int adksys_mpi_library_version(char* vendor, size_t vendor_len, char* version, size_t version_len)
+{
+   char info_buf[MPI_MAX_LIBRARY_VERSION_STRING];
+   int info_len = 0;
+
+   int err = MPI_Get_library_version(info_buf, &info_len);
+   if (err != MPI_SUCCESS)
+      return -1;
+
+   char* p = strstr(info_buf, "IBM Spectrum MPI");
+   if (p) {
+      /* Spectrum MPI is derived from Open MPI. The version info string looks like:
+         Open MPI v10.3.1.03rtm0, package: IBM Spectrum MPI, ident: IBM Spectrum MPI [...]
+       */
+       char* ver_str = NULL;
+       int ret = sscanf(info_buf, "Open MPI v%m[0-9a-z.]", &ver_str);
+       if (ret != 1)
+          return -1;
+       strncpy(vendor, "IBM Spectrum MPI", vendor_len);
+       strncpy(version, ver_str, version_len);
+       vendor[vendor_len-1] = '\0';
+       version[version_len-1] = '\0';
+       free(ver_str);
+       return 0;
+   }
+
+   p = strstr(info_buf, "CRAY MPICH");
+   if (p) {
+      /* Cray MPICH is derived from MPICH. The version info string looks like:
+         MPI VERSION    : CRAY MPICH version 8.1.27.20 [...]
+       */
+       char* ver_str = NULL;
+       int ret = sscanf(p, "CRAY MPICH version %m[0-9a-z.]", &ver_str);
+       if (ret != 1)
+          return -1;
+       strncpy(vendor, "CRAY MPICH", vendor_len);
+       strncpy(version, ver_str, version_len);
+       vendor[vendor_len-1] = '\0';
+       version[version_len-1] = '\0';
+       free(ver_str);
+       return 0;
+   }
+
+   p = strstr(info_buf, "MVAPICH2");
+   if (p) {
+      /* The version info string looks like:
+         MVAPICH2 Version      :\t2.3.7 [...]
+       */
+       p = strchr(info_buf, ':');
+       if (!p)
+          return -1;
+       char* ver_str = NULL;
+       int ret = sscanf(p, ": %m[0-9a-z.]", &ver_str);
+       if (ret != 1)
+          return -1;
+       strncpy(vendor, "MVAPICH2", vendor_len);
+       strncpy(version, ver_str, version_len);
+       vendor[vendor_len-1] = '\0';
+       version[version_len-1] = '\0';
+       free(ver_str);
+       return 0;
+   }
+
+   p = strstr(info_buf, "Open MPI");
+   if (p) {
+      /* The version info string looks like:
+         Open MPI v4.1.2, package: Open MPI [...]
+       */
+       char* ver_str = NULL;
+       int ret = sscanf(info_buf, "Open MPI v%m[0-9a-z.]", &ver_str);
+       if (ret != 1)
+          return -1;
+       strncpy(vendor, "Open MPI", vendor_len);
+       strncpy(version, ver_str, version_len);
+       vendor[vendor_len-1] = '\0';
+       version[version_len-1] = '\0';
+       free(ver_str);
+       return 0;
+   }
+
+   p = strstr(info_buf, "MPICH");
+   if (p) {
+      /* The version info string looks like:
+         MPICH Version      :3.4a2 [...]
+       */
+       p = strchr(info_buf, ':');
+       if (!p)
+          return -1;
+       char* ver_str = NULL;
+       int ret = sscanf(p, ": %m[0-9a-z.]", &ver_str);
+       if (ret != 1)
+          return -1;
+       strncpy(vendor, "MPICH", vendor_len);
+       strncpy(version, ver_str, version_len);
+       vendor[vendor_len-1] = '\0';
+       version[version_len-1] = '\0';
+       free(ver_str);
+       return 0;
+   }
+
+   return -1;
 }
 
 int adksys_reportable_rank()


### PR DESCRIPTION
Adds the "mpiversion" and "mpilibrary" name/value and calls. The "mpiversion" value is the MPI standard version (e.g. 3.1), and the "mpilibrary" value is the MPI library info reported by `MPI_Get_library_version()`.