### PR TITLE
Store records in shared object

### DIFF
--- a/src/adiak.c
+++ b/src/adiak.c
@@ -74,6 +74,7 @@ static adiak_datatype_t base_string_ref = { adiak_string, adiak_ordinal, 0, 0, N
 static adiak_datatype_t base_catstring_ref = { adiak_catstring, adiak_categorical, 0, 0, NULL, 1, 0 };
 static adiak_datatype_t base_path_ref = { adiak_path, adiak_categorical, 0, 0, NULL, 1, 0 };
 
+static void adiak_common_init();
 static void adiak_register(int adiak_version, int category,
                            adiak_nameval_cb_t nv,
                            int report_on_all_ranks, void *opaque_val);
@@ -98,7 +99,6 @@ static int measure_systime();
 static int measure_cputime();
 
 #define RECORD_HASH_SIZE 128
-static record_list_t *record_list_end;
 static record_list_t *record_hash[RECORD_HASH_SIZE];
 
 #define MAX_PATH_LEN 4096
@@ -122,6 +122,8 @@ int adiak_raw_namevalue(const char *name, int category, const char *subcategory,
       record_nameval(name, category, subcategory, value, type);
    if (!tool_list)
       return 0;
+
+   adiak_common_init();
 
    for (tool = (adiak_tool_t *) *tool_list; tool != NULL; tool = tool->next) {
       if (!tool->report_on_all_ranks && !adiak_config->reportable_rank)
@@ -247,6 +249,7 @@ void adiak_register_cb(int adiak_version, int category,
 void adiak_list_namevals(int adiak_version, int category, adiak_nameval_cb_t nv, void *opaque_val)
 {
    record_list_t *i;
+   adiak_common_init();
    for (i = adiak_config->shared_record_list; i != NULL; i = i->list_next) {
       if (category != adiak_category_all && i->category != category)
          continue;
@@ -258,6 +261,7 @@ void adiak_list_namevals(int adiak_version, int category, adiak_nameval_cb_t nv,
 int adiak_get_nameval(const char *name, adiak_datatype_t **t, adiak_value_t **value,  int *cat, const char **subcat)
 {
    record_list_t *i;
+   adiak_common_init();
    for (i = adiak_config->shared_record_list; i != NULL; i = i->list_next) {
       if (strcmp(i->name, name) == 0) {
          if (t)
@@ -906,14 +910,11 @@ static void record_nameval(const char *name, int category, const char *subcatego
       return;
 
    addrecord->name = (const char *) strdup(name);
-   addrecord->list_next = NULL;
-   if (!adiak_config->shared_record_list) {
-      adiak_config->shared_record_list = record_list_end = addrecord;
-   }
-   else {
-      record_list_end->list_next = addrecord;
-      record_list_end = addrecord;
-   }
+
+   adiak_common_init();
+
+   addrecord->list_next = adiak_config->shared_record_list;
+   adiak_config->shared_record_list = addrecord;
 
    addrecord->hash_next = record_hash[hashval];
    record_hash[hashval] = addrecord;
@@ -932,6 +933,8 @@ int adiak_clean()
    record_list_t *i, *next;
    int result;
 
+   adiak_common_init();
+
    val.v_int = 0;
    result = adiak_raw_namevalue("clean", adiak_control, NULL, &val, &base_int);
    for (i = adiak_config->shared_record_list; i != NULL; i = next) {
@@ -944,7 +947,7 @@ int adiak_clean()
       free(i);
    }
    memset(record_hash, 0, sizeof(record_hash));
-   adiak_config->shared_record_list = record_list_end = NULL;
+   adiak_config->shared_record_list = NULL;
    return result;
 }
 

--- a/src/adiak.c
+++ b/src/adiak.c
@@ -49,7 +49,7 @@ static adiak_t *adiak_config;
 static volatile adiak_tool_t **tool_list;
 
 static adiak_tool_t *local_tool_list;
-adiak_t adiak_public = { ADIAK_VERSION, ADIAK_VERSION, 0, 1, &local_tool_list, 0, 0 };
+adiak_t adiak_public = { ADIAK_VERSION, ADIAK_VERSION, 0, 1, &local_tool_list, 0, NULL };
 
 
 static int measure_adiak_walltime;


### PR DESCRIPTION
Stores the adiak records inside the shared `adiak_config` object instead of a static variable. This PR supersedes #27.