### PR TITLE
Adds Python bindings to Adiak

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,6 +42,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+          
+    - name: Install Python binding dependencies
+      run: |
+        python3 -m pip install pybind11 mpi4py
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -56,7 +60,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=${{matrix.config.cc}} -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}}
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=${{matrix.config.cc}} -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} -DWITH_PYTHON_BINDINGS=ON -Dpybind11_DIR=$(pybind11-config --cmakedir)
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR lib)
 endif()
 
+# Find Python by location
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
+  cmake_policy(SET CMP0094 NEW)
+endif()
+
 set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
 
 if (DEFINED BLT_SOURCE_DIR)
@@ -30,6 +35,19 @@ else()
 endif()
 
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
+
+option(WITH_PYTHON_BINDINGS "Build/Install Python bindings for Adiak" FALSE)
+
+if (WITH_PYTHON_BINDINGS)
+  find_package(Python COMPONENTS Interpreter Development REQUIRED)
+  find_package(pybind11 CONFIG REQUIRED)
+  
+  if (pybind11_FOUND)
+    set(ADIAK_HAVE_PYBIND11 TRUE)
+  else()
+    message(WARNING "Python bindings requested, but pybind11 not found")
+  endif()
+endif()
 
 add_subdirectory(src)
 if (ENABLE_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,3 +53,7 @@ install(TARGETS
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(EXPORT adiak-targets NAMESPACE adiak:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/adiak)
+
+if (WITH_PYTHON_BINDINGS)
+  add_subdirectory(interface/python)
+endif()

--- a/src/interface/python/CMakeLists.txt
+++ b/src/interface/python/CMakeLists.txt
@@ -1,0 +1,53 @@
+set(PYADIAK_BINDING_SOURCES
+    mod.cpp
+    pyadiak_tool.cpp
+    pyadiak.cpp
+    types.cpp
+)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
+set(PYADIAK_SYSCONFIG_SCHEME "posix_user" CACHE STRING "Scheme used for searching for pyadiak's install path. Valid options can be determined with 'sysconfig.get_scheme_names()'")
+
+execute_process(
+  COMMAND
+    ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/get_python_install_paths.py purelib ${PYADIAK_SYSCONFIG_SCHEME}
+  OUTPUT_VARIABLE
+    PYADIAK_SITELIB)
+execute_process(
+  COMMAND
+    ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/get_python_install_paths.py platlib ${PYADIAK_SYSCONFIG_SCHEME}
+  OUTPUT_VARIABLE
+    PYADIAK_SITEARCH)
+
+set(PYADIAK_SITELIB "${PYADIAK_SITELIB}/pyadiak")
+set(PYADIAK_SITEARCH "${PYADIAK_SITEARCH}/pyadiak")
+
+pybind11_add_module(__pyadiak_impl ${PYADIAK_BINDING_SOURCES})
+target_link_libraries(__pyadiak_impl PUBLIC adiak)
+target_compile_features(__pyadiak_impl PUBLIC cxx_std_11)
+target_include_directories(__pyadiak_impl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(
+    pyadiak_py_source_copy ALL # Always build pycaliper_test
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/pyadiak
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/pyadiak ${CMAKE_CURRENT_BINARY_DIR}/pyadiak
+    COMMENT "Copying pyadiak Python source to ${CMAKE_CURRENT_BINARY_DIR}/pyadiak"
+)
+add_dependencies(__pyadiak_impl pyadiak_py_source_copy)
+
+install(
+    DIRECTORY
+        pyadiak/
+    DESTINATION
+        ${PYADIAK_SITELIB}
+)
+
+install(
+    TARGETS
+        __pyadiak_impl
+    ARCHIVE DESTINATION
+        ${PYADIAK_SITEARCH}
+    LIBRARY DESTINATION
+        ${PYADIAK_SITEARCH}
+)

--- a/src/interface/python/common.hpp
+++ b/src/interface/python/common.hpp
@@ -1,0 +1,9 @@
+#ifndef ADIAK_INTERFACE_PYTHON_COMMON_HPP_
+#define ADIAK_INTERFACE_PYTHON_COMMON_HPP_
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#endif /* ADIAK_INTERFACE_PYTHON_COMMON_HPP_ */

--- a/src/interface/python/mod.cpp
+++ b/src/interface/python/mod.cpp
@@ -1,0 +1,13 @@
+#include "pyadiak.hpp"
+#include "pyadiak_tool.hpp"
+
+PYBIND11_MODULE(__pyadiak_impl, m) {
+  // TODO add version
+
+  auto annotation_module =
+      m.def_submodule("annotation", "Submodule for annotation APIs");
+  adiak::python::create_adiak_annotation_mod(annotation_module);
+
+  auto tool_module = m.def_submodule("tool", "Submodule for tool APIs");
+  adiak::python::create_adiak_tool_mod(tool_module);
+}

--- a/src/interface/python/mod.cpp
+++ b/src/interface/python/mod.cpp
@@ -4,6 +4,10 @@
 PYBIND11_MODULE(__pyadiak_impl, m) {
   // TODO add version
 
+  auto types_module =
+      m.def_submodule("types", "Submodule for type wrappers in Adiak");
+  adiak::python::create_adiak_types_mod(types_module);
+
   auto annotation_module =
       m.def_submodule("annotations", "Submodule for annotation APIs");
   adiak::python::create_adiak_annotation_mod(annotation_module);

--- a/src/interface/python/mod.cpp
+++ b/src/interface/python/mod.cpp
@@ -5,9 +5,9 @@ PYBIND11_MODULE(__pyadiak_impl, m) {
   // TODO add version
 
   auto annotation_module =
-      m.def_submodule("annotation", "Submodule for annotation APIs");
+      m.def_submodule("annotations", "Submodule for annotation APIs");
   adiak::python::create_adiak_annotation_mod(annotation_module);
 
-  auto tool_module = m.def_submodule("tool", "Submodule for tool APIs");
+  auto tool_module = m.def_submodule("tools", "Submodule for tool APIs");
   adiak::python::create_adiak_tool_mod(tool_module);
 }

--- a/src/interface/python/pyadiak.cpp
+++ b/src/interface/python/pyadiak.cpp
@@ -57,48 +57,6 @@ template <> struct type_caster<mpi4py_comm> {
 namespace adiak {
 namespace python {
 
-Timepoint::Timepoint(std::chrono::system_clock::time_point time)
-    : DataContainer<std::chrono::system_clock::time_point, struct timeval *>(
-          time) {}
-
-struct timeval *Timepoint::to_adiak() const {
-  auto time_since_epoch = std::chrono::duration_cast<std::chrono::microseconds>(
-      m_v.time_since_epoch());
-  m_time_for_adiak.tv_sec = time_since_epoch.count() / 1000000;
-  m_time_for_adiak.tv_usec = time_since_epoch.count() % 1000000;
-  return &m_time_for_adiak;
-}
-
-Date::Date(std::chrono::system_clock::time_point time)
-    : DataContainer<std::chrono::system_clock::time_point, adiak::date>(time) {}
-
-adiak::date Date::to_adiak() const {
-  auto time_since_epoch = std::chrono::duration_cast<std::chrono::seconds>(
-      value.time_since_epoch());
-  return adiak::date(time_since_epoch.count());
-}
-
-Version::Version(const std::string &ver)
-    : DataContainer<std::string, adiak::version>(ver) {}
-
-adiak::version Version::to_adiak() const { return adiak::version(m_v); }
-
-Path::Path(const std::string &p) : DataContainer<std::string, adiak::path>(p) {}
-
-adiak::path Path::to_adiak() const { return adiak::path(m_v); }
-
-CatStr::CatStr(const std::string &cs)
-    : DataContainer<std::string, adiak::catstring>(cs) {}
-
-adiak::catstringCatStr::to_adiak() const { return adiak::catstring(m_v); }
-
-CatStr::to_adiak() const { return adiak::catstring(m_v); }
-
-JsonStr::JsonStr(const std::string &js)
-    : DataContainer<std::string, adiak::jsonstring>(js) {}
-
-adiak::jsonstring JsonStr::to_adiak() const { return adiak::jsonstring(m_v); }
-
 // Custom wrapper for adiak::init
 // The only difference is that it uses the behavior of the pybind11
 // type_caster above to decide whether to pass an MPI communicator
@@ -158,28 +116,6 @@ void create_adiak_annotation_mod(py::module_ &mod) {
     throw std::runtime_error(
         "Cannot load mpi4py within the Adiak Python bindings");
   }
-
-  // Bind the custom data containers to Python.
-  // Note that we don't wrap the DataContainer base class or the 'to_adiak'
-  // methods because we don't need those exposed to Python.
-  py::class_<adiak::python::Timepoint>(mod, "Timepoint")
-      .def(py::init<std::chrono::system_clock::time_point>())
-      .def("to_python", &adiak::python::Timepoint::to_python);
-  py::class_<adiak::python::Date>(mod, "Date")
-      .def(py::init<std::chrono::system_clock::time_point>())
-      .def("to_python", &adiak::python::Timepoint::to_python);
-  py::class_<adiak::python::Version>(mod, "Version")
-      .def(py::init<const std::string &>())
-      .def("to_python", &adiak::python::Timepoint::to_python);
-  py::class_<adiak::python::Path>(mod, "Path")
-      .def(py::init<const std::string &>())
-      .def("to_python", &adiak::python::Timepoint::to_python);
-  py::class_<adiak::python::CatStr>(mod, "CatStr")
-      .def(py::init<const std::string &>())
-      .def("to_python", &adiak::python::Timepoint::to_python);
-  py::class_<adiak::python::JsonStr>(mod, "JsonStr")
-      .def(py::init<const std::string &>())
-      .def("to_python", &adiak::python::Timepoint::to_python);
 
   // Bind 'init' and 'fini'
   mod.def("init", &adiak::python::init);

--- a/src/interface/python/pyadiak.cpp
+++ b/src/interface/python/pyadiak.cpp
@@ -1,0 +1,319 @@
+#include "pyadiak.hpp"
+#include "adiak.hpp"
+#include <mpi.h>
+#include <mpi4py/mpi4py.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <set>
+#include <type_traits>
+
+namespace adiak {
+namespace python {
+
+// Bindings for MPI Comm derived from this StackOverflow post:
+// https://stackoverflow.com/a/62449190
+struct mpi4py_comm {
+  mpi4py_comm() = default;
+
+  mpi4py_comm(MPI_Comm comm) : m_comm(comm) {}
+
+  MPI_Comm m_comm;
+};
+
+namespace pybind11 {
+namespace detail {
+
+template <> struct type_caster<mpi4py_comm> {
+  PYBIND11_TYPE_CASTER(mpi4py_comm, _("mpi4py_comm"));
+
+  bool load(py::handle src, bool) {
+    // If the comm is None, produce a mpi4py_comm object with m_comm set to
+    // MPI_COMM_NULL
+    if (src == py::none()) {
+      value.m_comm = MPI_COMM_NULL;
+      return !PyErr_Occured();
+    }
+    // Get the underlying PyObject pointer to the mpi4py object
+    PyObject *py_capi_comm = src.ptr();
+    // Make sure the PyObject pointer's underlying type is mpi4py's
+    // PyMPIComm_Type. If the type check passes, use PyMPIComm_Get (from
+    // mpi4py's C API) to get the actual MPI_Comm. If the type check fails, tell
+    // pybind11 that the conversion is invalid.
+    if (PyObject_TypeCheck(py_capi_comm, &PyMPIComm_Type)) {
+      value.m_comm = *PyMPIComm_Get(py_capi_comm);
+    } else {
+      return false;
+    }
+    // Tell pybind11 that the conversion to C++ was successfull so long as there
+    // were no Python errors
+    return !PyErr_Occured();
+  }
+
+  static py::handle cast(mpi4py_comm src, py::return_value_policy, py::handle) {
+    return PyMPIComm_New(src.m_comm);
+  }
+};
+
+} // namespace detail
+} // namespace pybind11
+
+// The 'is_templated_base_of' type trait is derived from the following
+// StackOverflow post:
+// https://stackoverflow.com/a/49163138
+template <template <typename...> class Base, typename Derived,
+          typename TCheck = void>
+struct is_templated_base_of_tester;
+
+template <template <typename...> class Base, typename Derived>
+struct is_templated_base_of_tester<
+    Base, Derived, std::enable_if_t<std::is_class<Derived>::value>> : Derived {
+  template <typename... T> static constexpr std::true_type test(Base<T...> *);
+  static constexpr std::false_type test(...);
+  using is_base = decltype(test((is_templated_base_of_tester *)nullptr));
+};
+
+template <template <typename...> class Base, typename Derived>
+struct is_templated_base_of_tester<
+    Base, Derived, std::enable_if_t<!std::is_class<Derived>::value>> {
+  using is_base = std::false_type;
+};
+
+template <template <typename...> class Base, typename Derived>
+using is_templated_base_of =
+    typename is_templated_base_of_tester<Base, Derived>::is_base;
+
+template <typename T, class adiak_type> struct DataContainer {
+  T m_v;
+
+  DataContainer(T val) : m_v(val) {}
+
+  virtual adiak_type to_adiak() const = 0;
+};
+
+// Python-compatible struct for storing timepoint info
+// that will be converted into 'struct timeval' for Adiak
+struct Timepoint : public DataContainer<std::chrono::system_clock::time_point,
+                                        struct timeval *> {
+  struct timeval m_time_for_adiak;
+
+  Timepoint(std::chrono::system_clock::time_point time)
+      : DataContainer<std::chrono::system_clock::time_point, struct timeval *>(
+            time) {}
+
+  struct timeval *to_adiak() const final {
+    auto time_since_epoch =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            m_v.time_since_epoch());
+    m_time_for_adiak.tv_sec = time_since_epoch.count() / 1000000;
+    m_time_for_adiak.tv_usec = time_since_epoch.count() % 1000000;
+    return &m_time_for_adiak;
+  }
+};
+
+// Python-compatible struct for storing date or datetime info
+// that will be converted into 'adiak::date' for Adiak
+struct Date
+    : public DataContainer<std::chrono::system_clock::time_point, adiak::date> {
+  Date(std::chrono::system_clock::time_point time)
+      : DataContainer<std::chrono::system_clock::time_point, adiak::date>(
+            time) {}
+
+  adiak::date to_adiak() const final {
+    auto time_since_epoch = std::chrono::duration_cast<std::chrono::seconds>(
+        value.time_since_epoch());
+    return adiak::date(time_since_epoch.count());
+  }
+};
+
+// Python-compatible struct for storing version info
+// that will be converted into 'adiak::version' for Adiak
+struct Version : public DataContainer<std::string, adiak::version> {
+  Version(const std::string &ver)
+      : DataContainer<std::string, adiak::version>(ver) {}
+
+  adiak::version to_adiak() const final { return adiak::version(m_v); }
+};
+
+// TODO replace use of string with std::filesystem if/when C++17 is supported
+// Python-compatible struct for storing path info
+// that will be converted into 'adiak::path' for Adiak
+struct Path : public DataContainer<std::string, adiak::path> {
+  Path(const std::string &p) : DataContainer<std::string, adiak::path>(p) {}
+
+  adiak::path to_adiak() const final { return adiak::path(m_v); }
+};
+
+// Python-compatible struct for storing categorical string info
+// that will be converted into 'adiak::catstring' for Adiak
+struct CatStr : public DataContainer<std::string, adiak::catstring> {
+  CatStr(const std::string &cs)
+      : DataContainer<std::string, adiak::catstring>(cs) {}
+
+  adiak::catstring to_adiak() const { return adiak::catstring(m_v); }
+};
+
+// Python-compatible struct for storing JSON string info
+// that will be converted into 'adiak::jsonstring' for Adiak
+struct JsonStr : public DataContainer<std::string, adiak::jsonstring> {
+  JsonStr(const std::string &js)
+      : DataContainer<std::string, adiak::jsonstring>(js) {}
+
+  adiak::jsonstring to_adiak() const { return adiak::jsonstring(m_v); }
+};
+
+// Custom wrapper for adiak::init
+// The only difference is that it uses the behavior of the pybind11
+// type_caster above to decide whether to pass an MPI communicator
+// to adiak::init
+void init(mpi4py_comm comm) {
+  if (comm.m_comm == MPI_COMM_NULL) {
+    adiak::init(nullptr);
+  } else {
+    adiak::init(&comm.m_comm);
+  }
+}
+
+// Custom version of adiak::value for subclasses of DataContainer
+template <class T, typename = std::enable_if_t<
+                       std::is_templated_base_of<DataContainer, T>::value>>
+bool value(std::string name, T value, int category = adiak_general,
+           std::string subcategory = "") {
+  return adiak::value(name, value.to_adiak(), category, subcategory);
+}
+
+// Custom version of adiak::value for vectors of subclasses of DataContainer
+template <class T, typename = std::enable_if_t<
+                       std::is_templated_base_of<DataContainer, T>::value>>
+bool value_vec(std::string name, std::vector<T> value,
+               int category = adiak_general, std::string subcategory = "") {
+  std::vector<std::result_of<decltype (&T::to_adiak)()>::type> adiak_vec;
+  std::transform(value.cbegin(), value.cend(), adiak_vec.cbegin(),
+                 [](T v) { return v.to_adiak(); });
+  return adiak::value(name, adiak_vec, category, subcategory);
+}
+
+// Custom version of adiak::value for sets of subclasses of DataContainer
+template <class T, typename = std::enable_if_t<
+                       std::is_templated_base_of<DataContainer, T>::value>>
+bool value_set(std::string name, std::set<T> value,
+               int category = adiak_general, std::string subcategory = "") {
+  std::set<std::result_of<decltype (&T::to_adiak)()>::type> adiak_set;
+  std::transform(value.cbegin(), value.cend(), adiak_set.cbegin(),
+                 [](T v) { return v.to_adiak(); });
+  return adiak::value(name, adiak_set, category, subcategory);
+}
+
+// Macros to help generate the lambdas that pybind11 needs to bind the inline
+// functions in adiak.hpp
+//
+// clang-format off
+#define GENERATE_API_CALL_NO_ARGS(name)                                                \
+  [](){ return adiak::name(); }
+#define GENERATE_API_CALL_ONE_ARG(name, arg_type) [](arg_type val){ return adiak::name(val); }
+// clang-format on
+
+// Function to populate the Python module
+void create_adiak_annotation_mod(py::module_ &mod) {
+  // Try to import mpi4py so that we can early abort if
+  // we can't properly create bindings
+  if (import_mpi4py() < 0) {
+    throw std::runtime_error(
+        "Cannot load mpi4py within the Adiak Python bindings");
+  }
+
+  // Bind the custom data containers to Python.
+  // Note that we don't wrap the DataContainer base class or the 'to_adiak'
+  // methods because we don't need those exposed to Python.
+  py::class_<adiak::python::Timepoint>(mod, "Timepoint")
+      .def(py::init<std::chrono::system_clock::time_point>());
+  py::class_<adiak::python::Date>(mod, "Date")
+      .def(py::init<std::chrono::system_clock::time_point>());
+  py::class_<adiak::python::Version>(mod, "Version")
+      .def(py::init<const std::string &>());
+  py::class_<adiak::python::Path>(mod, "Path")
+      .def(py::init<const std::string &>());
+  py::class_<adiak::python::CatStr>(mod, "CatStr")
+      .def(py::init<const std::string &>());
+  py::class_<adiak::python::JsonStr>(mod, "JsonStr")
+      .def(py::init<const std::string &>());
+
+  // Bind 'init' and 'fini'
+  mod.def("init", &adiak::python::init);
+  mod.def("fini", GENERATE_API_CALL_NO_ARGS(fini));
+  // Python has no concept of templates, so pybind11 requires
+  // us to specify the types for all template functions. The requires us to
+  // iterate over all acceptable value types for adiak::value.
+  //
+  // Because we need to use Python-compatible types everywhere,
+  // we use special wrappers for types not natively supported by pybind11.
+  // To bridge these types to Adiak, we use custom versions of "value".
+  //
+  // We map all these specializations to the Python "value" function.
+  // Pybind11 will do the work of selecting the correct version of this
+  // function for us.
+  mod.def("value", &adiak::value<int8_t>);
+  mod.def("value", &adiak::value<uint64_t>);
+  mod.def("value", &adiak::value<double>);
+  mod.def("value", &adiak::value<std::string>);
+  mod.def("value", &adiak::python::value<adiak::python::Timepoint>);
+  mod.def("value", &adiak::python::value<adiak::python::Date>);
+  mod.def("value", &adiak::python::value<adiak::python::Version>);
+  mod.def("value", &adiak::python::value<adiak::python::Path>);
+  mod.def("value", &adiak::python::value<adiak::python::CatStr>);
+  mod.def("value", &adiak::python::value<adiak::python::JsonStr>);
+  mod.def("value", &adiak::value<std::vector<int8_t>>);
+  mod.def("value", &adiak::value<std::vector<uint64_t>>);
+  mod.def("value", &adiak::value<std::vector<double>>);
+  mod.def("value", &adiak::value<std::vector<std::string>>);
+  mod.def("value", &adiak::python::value_vec<adiak::python::Timepoint>);
+  mod.def("value", &adiak::python::value_vec<adiak::python::Date>);
+  mod.def("value", &adiak::python::value_vec<adiak::python::Version>);
+  mod.def("value", &adiak::python::value_vec<adiak::python::Path>);
+  mod.def("value", &adiak::python::value_vec<adiak::python::CatStr>);
+  mod.def("value", &adiak::python::value_vec<adiak::python::JsonStr>);
+  mod.def("value", &adiak::value<std::set<int8_t>>);
+  mod.def("value", &adiak::value<std::set<uint64_t>>);
+  mod.def("value", &adiak::value<std::set<double>>);
+  mod.def("value", &adiak::value<std::set<std::string>>);
+  mod.def("value", &adiak::python::value_set<adiak::python::Timepoint>);
+  mod.def("value", &adiak::python::value_set<adiak::python::Date>);
+  mod.def("value", &adiak::python::value_set<adiak::python::Version>);
+  mod.def("value", &adiak::python::value_set<adiak::python::Path>);
+  mod.def("value", &adiak::python::value_set<adiak::python::CatStr>);
+  mod.def("value", &adiak::python::value_set<adiak::python::JsonStr>);
+
+  // Bind all the other Adiak functions to custom lambda functions
+  // created by the GENERATE_API_CALL_* macros. These labmdas are
+  // used over the plain versions of these functions to avoid any issues
+  // with those functions being marked 'inline'.
+  mod.def("adiakversion", GENERATE_API_CALL_NO_ARGS(adiakversion));
+  mod.def("user", GENERATE_API_CALL_NO_ARGS(user));
+  mod.def("uid", GENERATE_API_CALL_NO_ARGS(uid));
+  mod.def("launchdate", GENERATE_API_CALL_NO_ARGS(launchdate));
+  mod.def("launchday", GENERATE_API_CALL_NO_ARGS(launchday));
+  mod.def("executable", GENERATE_API_CALL_NO_ARGS(executable));
+  mod.def("executablepath", GENERATE_API_CALL_NO_ARGS(executablepath));
+  mod.def("workdir", GENERATE_API_CALL_NO_ARGS(workdir));
+  mod.def("libraries", GENERATE_API_CALL_NO_ARGS(libraries));
+  mod.def("cmdline", GENERATE_API_CALL_NO_ARGS(cmdline));
+  mod.def("hostname", GENERATE_API_CALL_NO_ARGS(hostname));
+  mod.def("clustername", GENERATE_API_CALL_NO_ARGS(clustername));
+  mod.def("walltime", GENERATE_API_CALL_NO_ARGS(walltime));
+  mod.def("systime", GENERATE_API_CALL_NO_ARGS(systime));
+  mod.def("cputime", GENERATE_API_CALL_NO_ARGS(cputime));
+  mod.def("jobsize", GENERATE_API_CALL_NO_ARGS(jobsize));
+  mod.def("hostlist", GENERATE_API_CALL_NO_ARGS(hostlist));
+  mod.def("numhosts", GENERATE_API_CALL_NO_ARGS(numhosts));
+  mod.def("mpi_version", GENERATE_API_CALL_NO_ARGS(mpi_version));
+  mod.def("mpi_library", GENERATE_API_CALL_NO_ARGS(mpi_library));
+  mod.def("mpi_library_version",
+          GENERATE_API_CALL_NO_ARGS(mpi_library_version));
+  mod.def("flush", GENERATE_API_CALL_ONE_ARG(flush, std::string));
+  mod.def("clean", GENERATE_API_CALL_NO_ARGS(clean));
+  mod.def("collect_all", GENERATE_API_CALL_NO_ARGS(collect_all));
+}
+
+} // namespace python
+} // namespace adiak

--- a/src/interface/python/pyadiak.hpp
+++ b/src/interface/python/pyadiak.hpp
@@ -1,101 +1,10 @@
 #ifndef ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_
 #define ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_
 
-#include "common.hpp"
-
-#include <chrono>
-#include <type_traits>
+#include "types.hpp"
 
 namespace adiak {
 namespace python {
-
-// The 'is_templated_base_of' type trait is derived from the following
-// StackOverflow post:
-// https://stackoverflow.com/a/49163138
-template <template <typename...> class Base, typename Derived,
-          typename TCheck = void>
-struct is_templated_base_of_tester;
-
-template <template <typename...> class Base, typename Derived>
-struct is_templated_base_of_tester<
-    Base, Derived, std::enable_if_t<std::is_class<Derived>::value>> : Derived {
-  template <typename... T> static constexpr std::true_type test(Base<T...> *);
-  static constexpr std::false_type test(...);
-  using is_base = decltype(test((is_templated_base_of_tester *)nullptr));
-};
-
-template <template <typename...> class Base, typename Derived>
-struct is_templated_base_of_tester<
-    Base, Derived, std::enable_if_t<!std::is_class<Derived>::value>> {
-  using is_base = std::false_type;
-};
-
-template <template <typename...> class Base, typename Derived>
-using is_templated_base_of =
-    typename is_templated_base_of_tester<Base, Derived>::is_base;
-
-template <typename T, class adiak_type> struct DataContainer {
-  T m_v;
-
-  DataContainer(T val) : m_v(val) {}
-
-  virtual T to_python() const { return m_v; }
-
-  virtual adiak_type to_adiak() const = 0;
-};
-
-// Python-compatible struct for storing timepoint info
-// that will be converted into 'struct timeval' for Adiak
-struct Timepoint : public DataContainer<std::chrono::system_clock::time_point,
-                                        struct timeval *> {
-  struct timeval m_time_for_adiak;
-
-  Timepoint(std::chrono::system_clock::time_point time);
-
-  struct timeval *to_adiak() const final;
-};
-
-// Python-compatible struct for storing date or datetime info
-// that will be converted into 'adiak::date' for Adiak
-struct Date
-    : public DataContainer<std::chrono::system_clock::time_point, adiak::date> {
-  Date(std::chrono::system_clock::time_point time);
-
-  adiak::date to_adiak() const final;
-};
-
-// Python-compatible struct for storing version info
-// that will be converted into 'adiak::version' for Adiak
-struct Version : public DataContainer<std::string, adiak::version> {
-  Version(const std::string &ver);
-
-  adiak::version to_adiak() const final;
-};
-
-// TODO replace use of string with std::filesystem if/when C++17 is supported
-// Python-compatible struct for storing path info
-// that will be converted into 'adiak::path' for Adiak
-struct Path : public DataContainer<std::string, adiak::path> {
-  Path(const std::string &p);
-
-  adiak::path to_adiak() const final;
-};
-
-// Python-compatible struct for storing categorical string info
-// that will be converted into 'adiak::catstring' for Adiak
-struct CatStr : public DataContainer<std::string, adiak::catstring> {
-  CatStr(const std::string &cs);
-
-  adiak::catstring to_adiak() const final;
-};
-
-// Python-compatible struct for storing JSON string info
-// that will be converted into 'adiak::jsonstring' for Adiak
-struct JsonStr : public DataContainer<std::string, adiak::jsonstring> {
-  JsonStr(const std::string &js);
-
-  adiak::jsonstring to_adiak() const final;
-};
 
 void create_adiak_annotation_mod(py::module_ &mod);
 

--- a/src/interface/python/pyadiak.hpp
+++ b/src/interface/python/pyadiak.hpp
@@ -1,0 +1,14 @@
+#ifndef ADIAK_INTERFACE_PYTHON_ADIAK_HPP_
+#define ADIAK_INTERFACE_PYTHON_ADIAK_HPP_
+
+#include "common"
+
+namespace adiak {
+namespace python {
+
+void create_adiak_annotation_mod(py::module_ &mod);
+
+}
+} // namespace adiak
+
+#endif /* ADIAK_INTERFACE_PYTHON_ADIAK_HPP_ */

--- a/src/interface/python/pyadiak.hpp
+++ b/src/interface/python/pyadiak.hpp
@@ -1,14 +1,105 @@
 #ifndef ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_
 #define ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_
 
-#include "common"
+#include "common.hpp"
+
+#include <chrono>
+#include <type_traits>
 
 namespace adiak {
 namespace python {
 
+// The 'is_templated_base_of' type trait is derived from the following
+// StackOverflow post:
+// https://stackoverflow.com/a/49163138
+template <template <typename...> class Base, typename Derived,
+          typename TCheck = void>
+struct is_templated_base_of_tester;
+
+template <template <typename...> class Base, typename Derived>
+struct is_templated_base_of_tester<
+    Base, Derived, std::enable_if_t<std::is_class<Derived>::value>> : Derived {
+  template <typename... T> static constexpr std::true_type test(Base<T...> *);
+  static constexpr std::false_type test(...);
+  using is_base = decltype(test((is_templated_base_of_tester *)nullptr));
+};
+
+template <template <typename...> class Base, typename Derived>
+struct is_templated_base_of_tester<
+    Base, Derived, std::enable_if_t<!std::is_class<Derived>::value>> {
+  using is_base = std::false_type;
+};
+
+template <template <typename...> class Base, typename Derived>
+using is_templated_base_of =
+    typename is_templated_base_of_tester<Base, Derived>::is_base;
+
+template <typename T, class adiak_type> struct DataContainer {
+  T m_v;
+
+  DataContainer(T val) : m_v(val) {}
+
+  virtual T to_python() const { return m_v; }
+
+  virtual adiak_type to_adiak() const = 0;
+};
+
+// Python-compatible struct for storing timepoint info
+// that will be converted into 'struct timeval' for Adiak
+struct Timepoint : public DataContainer<std::chrono::system_clock::time_point,
+                                        struct timeval *> {
+  struct timeval m_time_for_adiak;
+
+  Timepoint(std::chrono::system_clock::time_point time);
+
+  struct timeval *to_adiak() const final;
+};
+
+// Python-compatible struct for storing date or datetime info
+// that will be converted into 'adiak::date' for Adiak
+struct Date
+    : public DataContainer<std::chrono::system_clock::time_point, adiak::date> {
+  Date(std::chrono::system_clock::time_point time);
+
+  adiak::date to_adiak() const final;
+};
+
+// Python-compatible struct for storing version info
+// that will be converted into 'adiak::version' for Adiak
+struct Version : public DataContainer<std::string, adiak::version> {
+  Version(const std::string &ver);
+
+  adiak::version to_adiak() const final;
+};
+
+// TODO replace use of string with std::filesystem if/when C++17 is supported
+// Python-compatible struct for storing path info
+// that will be converted into 'adiak::path' for Adiak
+struct Path : public DataContainer<std::string, adiak::path> {
+  Path(const std::string &p);
+
+  adiak::path to_adiak() const final;
+};
+
+// Python-compatible struct for storing categorical string info
+// that will be converted into 'adiak::catstring' for Adiak
+struct CatStr : public DataContainer<std::string, adiak::catstring> {
+  CatStr(const std::string &cs);
+
+  adiak::catstring to_adiak() const final;
+};
+
+// Python-compatible struct for storing JSON string info
+// that will be converted into 'adiak::jsonstring' for Adiak
+struct JsonStr : public DataContainer<std::string, adiak::jsonstring> {
+  JsonStr(const std::string &js);
+
+  adiak::jsonstring to_adiak() const final;
+};
+
 void create_adiak_annotation_mod(py::module_ &mod);
 
-}
+} // namespace python
 } // namespace adiak
 
 #endif /* ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_ */

--- a/src/interface/python/pyadiak.hpp
+++ b/src/interface/python/pyadiak.hpp
@@ -1,5 +1,5 @@
-#ifndef ADIAK_INTERFACE_PYTHON_ADIAK_HPP_
-#define ADIAK_INTERFACE_PYTHON_ADIAK_HPP_
+#ifndef ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_
+#define ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_
 
 #include "common"
 
@@ -11,4 +11,4 @@ void create_adiak_annotation_mod(py::module_ &mod);
 }
 } // namespace adiak
 
-#endif /* ADIAK_INTERFACE_PYTHON_ADIAK_HPP_ */
+#endif /* ADIAK_INTERFACE_PYTHON_PYADIAK_HPP_ */

--- a/src/interface/python/pyadiak/annotations.py
+++ b/src/interface/python/pyadiak/annotations.py
@@ -1,1 +1,107 @@
-from pyadiak.__pyadiak_impl.annotations import *
+from datetime import date, datetime, time
+from pathlib import Path as PyPath
+from typing import Any
+from warnings import warn
+
+from pyadiak.__pyadiak_impl.annotations import (
+    adiakversion,
+    clean,
+    clustername,
+    cmdline,
+    collect_all,
+    cputime,
+    executable,
+    executablepath,
+    fini,
+    flush,
+    hostlist,
+    hostname,
+    jobsize,
+    launchdate,
+    launchday,
+    libraries,
+    mpi_library,
+    mpi_library_version,
+    mpi_version,
+    numhosts,
+    systime,
+    uid,
+    user,
+    walltime,
+    workdir,
+)
+from pyadiak.__pyadiak_impl.annotations import (
+    init as cpp_init,
+)
+from pyadiak.__pyadiak_impl.annotations import (
+    value as cpp_value,
+)
+from pyadiak.types import *
+
+
+def init(comm=None):
+    try:
+        from mpi4py.MPI import Comm
+
+        if comm is not None and not isinstance(comm, Comm):
+            raise TypeError(
+                "The 'comm' argument to 'init' must be of type mpi4py.MPI.Comm"
+            )
+        cpp_init(comm)
+    except ImportError:
+        if comm is not None:
+            warn(
+                "A value was passed to the 'comm' argument, but there is no way for it to be the correct type because mpi4py cannot be imported. If you want to pass an MPI communicator, install mpi4py first.",
+                RuntimeWarning,
+            )
+        cpp_init(None)
+
+
+def value(name: str, value: Any, category=Category.General, subcategory="") -> bool:
+    wrapped_value = value
+    if isinstance(value, date):
+        wrapped_value = Date(value)
+    elif isinstance(value, (time, datetime)):
+        wrapped_value = Timepoint(value)
+    elif isinstance(value, PyPath):
+        wrapped_value = Path(value)
+    if not isinstance(category, Category):
+        raise TypeError(
+            f"Invalid type ('{type(category)}') for 'category' parameter. Should be 'Category'"
+        )
+    if not isinstance(subcategory, str):
+        raise TypeError(
+            f"Invalid type ('{type(subcategory)}') for 'subcategory' parameter. Should be 'str'"
+        )
+    return cpp_value(name, wrapped_value, int(category), subcategory)
+
+
+__all__ = [
+    "init",
+    "fini",
+    "value",
+    "adiakversion",
+    "user",
+    "uid",
+    "launchdate",
+    "launchday",
+    "executable",
+    "executablepath",
+    "workdir",
+    "libraries",
+    "cmdline",
+    "hostname",
+    "clustername",
+    "walltime",
+    "systime",
+    "cputime",
+    "jobsize",
+    "hostlist",
+    "numhosts",
+    "mpi_version",
+    "mpi_library",
+    "mpi_library_version",
+    "flush",
+    "clean",
+    "collect_all",
+]

--- a/src/interface/python/pyadiak/annotations.py
+++ b/src/interface/python/pyadiak/annotations.py
@@ -1,0 +1,1 @@
+from pyadiak.__pyadiak_impl.annotations import *

--- a/src/interface/python/pyadiak/tools.py
+++ b/src/interface/python/pyadiak/tools.py
@@ -1,0 +1,1 @@
+from pyadiak.__pyadiak_impl.tools import *

--- a/src/interface/python/pyadiak/tools.py
+++ b/src/interface/python/pyadiak/tools.py
@@ -1,1 +1,155 @@
-from pyadiak.__pyadiak_impl.tools import *
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any, Callable, List, Tuple
+
+from pyadiak.__pyadiak_impl.tools import (
+    AdiakDataType,
+    AdiakNumerical,
+    AdiakTypeRaw,
+)
+from pyadiak.__pyadiak_impl.tools import (
+    get_nameval as cpp_get_nameval,
+)
+from pyadiak.__pyadiak_impl.tools import (
+    list_namevals as cpp_list_namevals,
+)
+from pyadiak.__pyadiak_impl.tools import (
+    register_cb as cpp_register_cb,
+)
+from pyadiak.__pyadiak_impl.tools import (
+    type_to_string as cpp_type_to_string,
+)
+from pyadiak.types import Category
+
+
+class Type(IntEnum):
+    Unset = AdiakTypeRaw.AdiakTypeUnset
+    Long = AdiakTypeRaw.AdiakTypeLong
+    ULong = AdiakTypeRaw.AdiakTypeULong
+    Int = AdiakTypeRaw.AdiakTypeInt
+    UInt = AdiakTypeRaw.AdiakTypeUInt
+    Double = AdiakTypeRaw.AdiakTypeDouble
+    Date = AdiakTypeRaw.AdiakTypeDate
+    Timeval = AdiakTypeRaw.AdiakTypeTimeval
+    Version = AdiakTypeRaw.AdiakTypeVersion
+    String = AdiakTypeRaw.AdiakTypeString
+    CatString = AdiakTypeRaw.AdiakTypeCatString
+    Path = AdiakTypeRaw.AdiakTypePath
+    Range = AdiakTypeRaw.AdiakTypeRange
+    Set = AdiakTypeRaw.AdiakTypeSet
+    List = AdiakTypeRaw.AdiakTypeList
+    Tuple = AdiakTypeRaw.AdiakTypeTuple
+    LongLong = AdiakTypeRaw.AdiakTypeLongLong
+    ULongLong = AdiakTypeRaw.AdiakTypeULongLong
+    JsonString = AdiakTypeRaw.AdiakTypeJsonString
+
+    @staticmethod
+    def from_cpp_type(v: AdiakTypeRaw) -> Type:
+        return Type(int(v))
+
+
+class Numerical(IntEnum):
+    Unset = AdiakNumerical.AdiakNumericalUnset
+    Categorical = AdiakNumerical.AdiakNumericalCategorical
+    Ordinal = AdiakNumerical.AdiakNumericalOrdinal
+    Interval = AdiakNumerical.AdiakNumericalInterval
+    Rational = AdiakNumerical.AdiakNumericalRational
+
+    @staticmethod
+    def from_cpp_numerical(v: AdiakNumerical) -> Numerical:
+        return Numerical(int(v))
+
+
+class DataType:
+    def __init__(self, raw_datatype: AdiakDataType):
+        self.dtype = raw_datatype
+
+    def get_dtype(self) -> Type:
+        cpp_type = self.dtype.get_dtype()
+        return Type.from_cpp_type(cpp_type)
+
+    def get_numerical(self) -> Numerical:
+        cpp_num = self.dtype.get_numerical()
+        return Numerical.from_cpp_numerical(cpp_num)
+
+    def get_num_elems(self) -> int:
+        return self.dtype.get_num_elems()
+
+    def get_num_subtypes_in_container(self) -> int:
+        return self.dtype.get_num_subtypes_in_container()
+
+    def is_reference(self) -> bool:
+        return self.dtype.is_reference()
+
+    def get_subtypes(self) -> List[DataType]:
+        cpp_types = self.get_subtypes()
+        return [DataType(ct) for ct in cpp_types]
+
+
+AdiakToolCallback = Callable[str, Category, str, Any, DataType]
+
+
+def __wrap_cb_in_caster_func(cb: AdiakToolCallback) -> Callable:
+    def __wrapper_func(
+        name: str, cat: int, subcat: str, val: Any, dtype: AdiakDataType
+    ):
+        local_category = Category(cat)
+        local_dtype = DataType(dtype)
+        cb(str, local_category, subcat, val, local_dtype)
+
+    return __wrapper_func
+
+
+def register_cb(
+    adiak_version: int,
+    cat: Category,
+    callback: AdiakToolCallback,
+    report_on_all_ranks: bool,
+):
+    if not isinstance(adiak_version, int):
+        raise TypeError("The 'adiak_version' parameter must be an int")
+    if not isinstance(cat, Category):
+        raise TypeError("The 'cat' parameter must be a 'pyadiak.types.Category'")
+    if not isinstance(callback, AdiakToolCallback):
+        raise TypeError(
+            "The 'callback' parameter must be a 'pyadiak.tools.AdiakToolCallback'"
+        )
+    wrapped_cb = __wrap_cb_in_caster_func(callback)
+    cpp_register_cb(adiak_version, int(cat), wrapped_cb, report_on_all_ranks)
+
+
+def list_namevals(adiak_version: int, cat: Category, callback: AdiakToolCallback):
+    if not isinstance(adiak_version, int):
+        raise TypeError("The 'adiak_version' parameter must be an int")
+    if not isinstance(cat, Category):
+        raise TypeError("The 'cat' parameter must be a 'pyadiak.types.Category'")
+    if not isinstance(callback, AdiakToolCallback):
+        raise TypeError(
+            "The 'callback' parameter must be a 'pyadiak.tools.AdiakToolCallback'"
+        )
+    wrapped_cb = __wrap_cb_in_caster_func(callback)
+    cpp_list_namevals(adiak_version, int(cat), wrapped_cb)
+
+
+def type_to_string(dtype: DataType, long_form=False) -> str:
+    if not isinstance(dtype, DataType):
+        raise TypeError("The 'dtype' parameter must be a 'pyadiak.tools.DataType'")
+    return cpp_type_to_string(dtype.dtype, long_form)
+
+
+def get_nameval(name: str) -> Tuple[DataType, Any, Category, str]:
+    cpp_tup = cpp_get_nameval(name)
+    return (DataType(cpp_tup[0]), cpp_tup[1], Category(cpp_tup[2]), cpp_tup[3])
+
+
+__all__ = [
+    "Type",
+    "Numerical",
+    "DataType",
+    "AdiakToolCallback",
+    "register_cb",
+    "list_namevals",
+    "type_to_string",
+    "get_nameval",
+]

--- a/src/interface/python/pyadiak/types.py
+++ b/src/interface/python/pyadiak/types.py
@@ -1,0 +1,26 @@
+from enum import IntEnum
+
+from pyadiak.__pyadiak_impl.types import (
+    ADIAK_CATEGORY_ALL,
+    ADIAK_CATEGORY_CONTROL,
+    ADIAK_CATEGORY_GENERAL,
+    ADIAK_CATEGORY_PERFORMANCE,
+    ADIAK_CATEGORY_UNSET,
+    CatStr,
+    Date,
+    JsonStr,
+    Path,
+    Timepoint,
+    Version,
+)
+
+
+class Category(IntEnum):
+    Unset = ADIAK_CATEGORY_UNSET
+    All = ADIAK_CATEGORY_ALL
+    General = ADIAK_CATEGORY_GENERAL
+    Performance = ADIAK_CATEGORY_PERFORMANCE
+    Control = ADIAK_CATEGORY_CONTROL
+
+
+__all__ = ["CatStr", "Date", "JsonStr", "Path", "Timepoint", "Version", "Category"]

--- a/src/interface/python/pyadiak_tool.cpp
+++ b/src/interface/python/pyadiak_tool.cpp
@@ -1,16 +1,182 @@
 #include "pyadiak_tool.hpp"
 #include "adiak_tool.h"
+#include "pyadiak.hpp"
+
+#include <chrono>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
 
 namespace adiak {
 namespace python {
+
+class PyadiakDataType {
+public:
+  PyadiakDataType() = default;
+
+  PyadiakDataType(adiak_datatype_t *c_type)
+      : m_adiak_dtype_ptr(c_type), m_dtype(c_type->dtype),
+        m_numerical(c_type->numerical), m_num_elems(c_type->num_elements),
+        m_num_subtypes(c_type->num_subtypes), m_subtypes(),
+        m_is_reference(c_type->is_reference == 0 ? false : true),
+        m_num_ref_elements(c_type->num_ref_elements) {
+    for (int i = 0; i < m_num_subtypes; i++) {
+      m_subtypes.push_back(PyadiakDataType(c_type->subtype[i]));
+    }
+  }
+
+  adiak_type_t get_dtype() const { return m_dtype; }
+
+  adiak_numerical_t get_numerical() const { return m_numerical; }
+
+  int get_num_elems() const {
+    if (m_is_reference) {
+      return m_num_ref_elements;
+    } else {
+      return m_num_elems;
+    }
+  }
+
+  int get_num_subtypes_in_container() const { return m_num_subtypes; }
+
+  bool is_reference() const { return m_is_reference; }
+
+  std::vector<PyadiakDataType> get_subtypes() const { return m_subtypes; }
+
+  adiak_datatype_t *get_adiak_dtype() { return m_adiak_dtype_ptr; }
+
+private:
+  adiak_datatype_t *m_adiak_dtype_ptr;
+  adiak_type_t m_dtype;
+  adiak_numerical_t m_numerical;
+  int m_num_elems;
+  int m_num_subtypes;
+  std::vector<PyadiakDataType> m_subtypes;
+  bool m_is_reference;
+  int m_num_ref_elements;
+};
+
+py::object convert_adiak_value_to_python(adiak_value_t *val,
+                                         adiak_datatype_t *type) {
+  // TODO import pyadiak module to get proper casting of data containers to
+  // py::object
+  switch (type->dtype) {
+  case adiak_long:
+    return py::cast<py::int_>(val->v_long);
+    break;
+  case adiak_ulong:
+    return py::cast<py::int_>((unsigned long)val->v_long);
+    break;
+  case adiak_int:
+    return py::cast<py::int_>(val->v_int);
+    break;
+  case adiak_uint:
+    return py::cast<py::int_>((unsigned int)val->v_int);
+    break;
+  case adiak_double:
+    return py::cast<py::float_>(val->v_double);
+  case adiak_date:
+    std::chrono::seconds chrono_seconds(val->v_long);
+    return py::cast(adiak::python::Date(
+        std::chrono::system_clock::time_point(chrono_seconds)));
+    break;
+  case adiak_timeval:
+    uint64_t num_microseconds = val->v_ptr->tv_sec * 1000000;
+    num_microseconds += val->v_ptr->tv_usec;
+    std::chrono::microseconds chrono_usec(num_microseconds);
+    return py::cast(adiak::python::Timepoint(
+        std::chrono::system_clock::time_point(chrono_usec)));
+    break;
+  case adiak_version:
+    return py::cast(adiak::python::Version(std::string(val->v_ptr)));
+    break;
+  case adiak_string:
+    return py::cast<py::str>(std::string(val->v_ptr));
+    break;
+  case adiak_catstring:
+    return py::cast(adiak::python::CatStr(std::string(val->v_ptr)));
+    break;
+  case adiak_jsonstring:
+    return py::cast(adiak::python::JsonStr(std::string(val->v_ptr)));
+    break;
+  case adiak_path:
+    return py::cast(adiak::python::Path(std::string(val->v_ptr)));
+    break;
+  case adiak_range:
+    if (type->num_subtypes != 2) {
+      throw std::runtime_error(
+          "Mismatch in Adiak between 'range' type and number of subtypes");
+    }
+    std::tuple<py::object, py::object> range_tuple = std::make_tuple(
+        convert_adiak_value_to_python(&(val->v_subval[0]), type->subtype[0]),
+        convert_adiak_value_to_python(&(val->v_subval[1]), type->subtype[1]));
+    return py::cast<py::tuple>(range_tuple);
+    break;
+  case adiak_set:
+    if (type->num_subtypes != 1) {
+      throw std::runtime_error(
+          "Mismatch in Adiak between 'set' type and number of subtypes");
+    }
+    adiak_datatype_t *subtype = type->subtype[0];
+    int num_elems =
+        type->is_reference != 0 ? type->num_ref_elements : type->num_elements;
+    std::set<py::object> set_val;
+    for (int i = 0; i < num_elems; i++) {
+      set_val.insert(
+          convert_adiak_value_to_python(&(val->v_subval[i]), subtype));
+    }
+    return py::cast<py::set>(set_val);
+    break;
+  case adiak_list:
+    if (type->num_subtypes != 1) {
+      throw std::runtime_error(
+          "Mismatch in Adiak between 'list' type and number of subtypes");
+    }
+    adiak_datatype_t *subtype = type->subtype[0];
+    int num_elems =
+        type->is_reference != 0 ? type->num_ref_elements : type->num_elements;
+    std::vector<py::object> list_val;
+    for (int i = 0; i < num_elems; i++) {
+      list_val.push_back(
+          convert_adiak_value_to_python(&(val->v_subval[i]), subtype));
+    }
+    return py::cast<py::list>(list_val);
+    break;
+  case adiak_tuple:
+    int num_subtypes = type->num_subtypes;
+    int num_elems =
+        type->is_reference != 0 ? type->num_ref_elements : type->num_elements;
+    if (num_subtypes != num_elems) {
+      throw std::runtime_error(
+          "Mismatch in Adiak between 'tuple' type and number of subtypes")
+    }
+    std::vector<py::object> list_val;
+    for (int i = 0; i < num_elems; i++) {
+      list_val.push_back(
+          convert_adiak_value_to_python(&(val->v_subval[i]), type->subtype[i]));
+    }
+    py::tuple tup_val = py::cast(list_val);
+    return tup_val;
+    break;
+  case adiak_longlong:
+    return py::cast<py::int_>(val->v_longlong);
+    break;
+  case adiak_ulonglong:
+    return py::cast<py::int_>(val->v_ulonglong);
+    break;
+  default:
+    throw std::runtime_error("Invalid datatype obtained from Adiak");
+  }
+}
 
 void pyadiak_tool_nameval_cb(const char *name, int category,
                              const char *subcategory, adiak_value_t *value,
                              adiak_datatype_t *t, void *py_cb) {
   py::handle nv_cb((PyObject *)py_cb);
-  // TODO add any necessary conversion from adiak_value_t and adiak_datatype_t
-  // to correct Python-compatible types
-  nv_cb(name, category, subcategory, value, t);
+  PyadiakDataType py_dtype(t);
+  py::object py_val = convert_adiak_value_to_python(value, t);
+  nv_cb(name, category, subcategory, py_val, py_dtype);
 }
 
 void pyadiak_register_cb(int adiak_version, int category, py::function nv_cb,
@@ -29,19 +195,77 @@ void pyadiak_list_namevals(int adiak_version, int category,
                       (void *)nv_cb_obj);
 }
 
-std::string pyadiak_type_to_string(adiak_datatype_t *t, bool long_form) {
-  // TODO implement once I figure out how to handle dtypes
-  return std::string("");
+std::string pyadiak_type_to_string(PyadiakDataType &type, bool long_form) {
+  adiak_datatype_t *adiak_dtype = type.get_adiak_dtype();
+  if (adiak_dtype == nullptr) {
+    throw std::runtime_error("Provided DataType is invalid");
+  }
+  char *alloced_str = adiak_type_to_string(adiak_dtype, long_form ? 1 : 0);
+  if (alloced_str == nullptr) {
+    throw std::runtime_error("Failed to get string for type");
+  }
+  std::string py_str(alloced_str);
+  free(alloced_str);
+  return py_str;
 }
 
-std::tuple<adiak_datatype_t *, adiak_value_t *, int, const char *>
+std::tuple<PyadiakDataType, py::object, int, const char *>
 pyadiak_get_nameval(const char *name) {
-  // TODO implement once I figure out how to handle dtypes and values
+  adiak_datatype_t *dtype = nullptr;
+  adiak_value_t *val = nullptr;
+  int category = 0;
+  const char *subcat = nullptr;
+  int rc = adiak_get_nameval(name, &dtype, &val, &category, &subcat);
+  if (rc != 0) {
+    throw std::runtime_error("Failed to get value for name");
+  }
+  py::object py_val = convert_adiak_value_to_python(val, dtype);
+  PyadiakDataType py_dtype(dtype);
+  return std::make_tuple(py_dtype, py_val, category, subcat);
 }
 
-int pyadiak_num_subvals(adiak_datatype_t *t) {
-  // TODO implement once I figure out how to handle dtypes
-  return 0;
+void create_adiak_tool_mod(py::module_ &mod) {
+  py::enum_<adiak_type_t>(mod, "AdiakTypeRaw")
+      .value("AdiakTypeUnset", adiak_type_unset)
+      .value("AdiakTypeLong", adiak_long)
+      .value("AdiakTypeULong", adiak_ulong)
+      .value("AdiakTypeInt", adiak_int)
+      .value("AdiakTypeUInt", adiak_uint)
+      .value("AdiakTypeDouble", adiak_double)
+      .value("AdiakTypeDate", adiak_date)
+      .value("AdiakTypeTimeval", adiak_timeval)
+      .value("AdiakTypeVersion", adiak_version)
+      .value("AdiakTypeString", adiak_string)
+      .value("AdiakTypeCatString", adiak_catstring)
+      .value("AdiakTypePath", adiak_path)
+      .value("AdiakTypeRange", adiak_range)
+      .value("AdiakTypeSet", adiak_set)
+      .value("AdiakTypeList", adiak_list)
+      .value("AdiakTypeTuple", adiak_tuple)
+      .value("AdiakTypeLongLong", adiak_longlong)
+      .value("AdiakTypeULongLong", adiak_ulonglong)
+      .value("AdiakTypeJsonString", adiak_jsonstring)
+      .export_values();
+  py::enum_<adiak_numerical_t>(mod, "AdiakNumerical")
+      .value("AdiakNumericalUnset", adiak_numerical_unset)
+      .value("AdiakNumericalCategorical", adiak_categorical)
+      .value("AdiakNumericalOrdinal", adiak_ordinal)
+      .value("AdiakNumericalInterval", adiak_interval)
+      .value("AdiakNumericalRational", adiak_rational)
+      .export_values();
+  py::class_<PyadiakDataType>(mod, "DataType")
+      .def(py::init<>())
+      .def("get_dtype", &PyadiakDataType::get_dtype)
+      .def("get_numerical", &PyadiakDataType::get_numerical)
+      .def("get_num_elems", &PyadiakDataType::get_num_elems)
+      .def("get_num_subtypes_in_container",
+           &PyadiakDataType::get_num_subtypes_in_container)
+      .def("is_reference", &PyadiakDataType::is_reference)
+      .def("get_subtypes", &PyadiakDataType::get_subtypes);
+  m.def("register_cb", &pyadiak_register_cb);
+  m.def("list_namevals", &pyadiak_list_namevals);
+  m.def("type_to_string", &pyadiak_type_to_string);
+  m.def("get_nameval", &pyadiak_get_nameval);
 }
 
 } // namespace python

--- a/src/interface/python/pyadiak_tool.cpp
+++ b/src/interface/python/pyadiak_tool.cpp
@@ -1,6 +1,6 @@
 #include "pyadiak_tool.hpp"
 #include "adiak_tool.h"
-#include "pyadiak.hpp"
+#include "types.hpp"
 
 #include <chrono>
 #include <set>
@@ -253,7 +253,7 @@ void create_adiak_tool_mod(py::module_ &mod) {
       .value("AdiakNumericalInterval", adiak_interval)
       .value("AdiakNumericalRational", adiak_rational)
       .export_values();
-  py::class_<PyadiakDataType>(mod, "DataType")
+  py::class_<PyadiakDataType>(mod, "AdiakDataType")
       .def(py::init<>())
       .def("get_dtype", &PyadiakDataType::get_dtype)
       .def("get_numerical", &PyadiakDataType::get_numerical)

--- a/src/interface/python/pyadiak_tool.cpp
+++ b/src/interface/python/pyadiak_tool.cpp
@@ -59,7 +59,7 @@ private:
 
 py::object convert_adiak_value_to_python(adiak_value_t *val,
                                          adiak_datatype_t *type) {
-  // TODO import pyadiak module to get proper casting of data containers to
+  // TODO figure out if I need to do anything else to cast custom types to
   // py::object
   switch (type->dtype) {
   case adiak_long:

--- a/src/interface/python/pyadiak_tool.cpp
+++ b/src/interface/python/pyadiak_tool.cpp
@@ -1,0 +1,48 @@
+#include "pyadiak_tool.hpp"
+#include "adiak_tool.h"
+
+namespace adiak {
+namespace python {
+
+void pyadiak_tool_nameval_cb(const char *name, int category,
+                             const char *subcategory, adiak_value_t *value,
+                             adiak_datatype_t *t, void *py_cb) {
+  py::handle nv_cb((PyObject *)py_cb);
+  // TODO add any necessary conversion from adiak_value_t and adiak_datatype_t
+  // to correct Python-compatible types
+  nv_cb(name, category, subcategory, value, t);
+}
+
+void pyadiak_register_cb(int adiak_version, int category, py::function nv_cb,
+                         bool report_on_all_ranks) {
+  PyObject *nv_cb_obj = nv_cb.ptr();
+  Py_INCREF(nv_cb_obj);
+  adiak_register_cb(adiak_version, category, pyadiak_tool_nameval_cb,
+                    report_on_all_ranks ? 1 : 0, (void *)nv_cb_obj);
+}
+
+void pyadiak_list_namevals(int adiak_version, int category,
+                           py::function nv_cb) {
+  PyObject *nv_cb_obj = nv_cb.ptr();
+  Py_INCREF(nv_cb_obj);
+  adiak_list_namevals(adiak_version, category, pyadiak_tool_nameval_cb,
+                      (void *)nv_cb_obj);
+}
+
+std::string pyadiak_type_to_string(adiak_datatype_t *t, bool long_form) {
+  // TODO implement once I figure out how to handle dtypes
+  return std::string("");
+}
+
+std::tuple<adiak_datatype_t *, adiak_value_t *, int, const char *>
+pyadiak_get_nameval(const char *name) {
+  // TODO implement once I figure out how to handle dtypes and values
+}
+
+int pyadiak_num_subvals(adiak_datatype_t *t) {
+  // TODO implement once I figure out how to handle dtypes
+  return 0;
+}
+
+} // namespace python
+} // namespace adiak

--- a/src/interface/python/pyadiak_tool.hpp
+++ b/src/interface/python/pyadiak_tool.hpp
@@ -1,0 +1,14 @@
+#ifndef ADIAK_INTERFACE_PYTHON_PYADIAK_TOOL_HPP_
+#define ADIAK_INTERFACE_PYTHON_PYADIAK_TOOL_HPP_
+
+#include "common.hpp"
+
+namespace adiak {
+namespace python {
+
+void create_adiak_tool_annotation_mod(py::module_ &mod);
+
+}
+} // namespace adiak
+
+#endif /* ADIAK_INTERFACE_PYTHON_PYADIAK_TOOL_HPP_*/

--- a/src/interface/python/pyadiak_tool.hpp
+++ b/src/interface/python/pyadiak_tool.hpp
@@ -6,7 +6,7 @@
 namespace adiak {
 namespace python {
 
-void create_adiak_tool_annotation_mod(py::module_ &mod);
+void create_adiak_tool_mod(py::module_ &mod);
 
 }
 } // namespace adiak

--- a/src/interface/python/types.cpp
+++ b/src/interface/python/types.cpp
@@ -1,0 +1,79 @@
+#include "types.hpp"
+#include "adiak.hpp"
+
+namespace adiak {
+namespace python {
+
+Timepoint::Timepoint(std::chrono::system_clock::time_point time)
+    : DataContainer<std::chrono::system_clock::time_point, struct timeval *>(
+          time) {}
+
+struct timeval *Timepoint::to_adiak() const {
+  auto time_since_epoch = std::chrono::duration_cast<std::chrono::microseconds>(
+      m_v.time_since_epoch());
+  m_time_for_adiak.tv_sec = time_since_epoch.count() / 1000000;
+  m_time_for_adiak.tv_usec = time_since_epoch.count() % 1000000;
+  return &m_time_for_adiak;
+}
+
+Date::Date(std::chrono::system_clock::time_point time)
+    : DataContainer<std::chrono::system_clock::time_point, adiak::date>(time) {}
+
+adiak::date Date::to_adiak() const {
+  auto time_since_epoch = std::chrono::duration_cast<std::chrono::seconds>(
+      value.time_since_epoch());
+  return adiak::date(time_since_epoch.count());
+}
+
+Version::Version(const std::string &ver)
+    : DataContainer<std::string, adiak::version>(ver) {}
+
+adiak::version Version::to_adiak() const { return adiak::version(m_v); }
+
+Path::Path(const std::string &p) : DataContainer<std::string, adiak::path>(p) {}
+
+adiak::path Path::to_adiak() const { return adiak::path(m_v); }
+
+CatStr::CatStr(const std::string &cs)
+    : DataContainer<std::string, adiak::catstring>(cs) {}
+
+adiak::catstringCatStr::to_adiak() const { return adiak::catstring(m_v); }
+
+CatStr::to_adiak() const { return adiak::catstring(m_v); }
+
+JsonStr::JsonStr(const std::string &js)
+    : DataContainer<std::string, adiak::jsonstring>(js) {}
+
+adiak::jsonstring JsonStr::to_adiak() const { return adiak::jsonstring(m_v); }
+
+void create_adiak_types_mod(py::module_ &mod) {
+  mod.attr("ADIAK_CATEGORY_UNSET") = py::int_(adiak_category_unset);
+  mod.attr("ADIAK_CATEGORY_ALL") = py::int_(adiak_category_all);
+  mod.attr("ADIAK_CATEGORY_GENERAL") = py::int_(adiak_general);
+  mod.attr("ADIAK_CATEGORY_PERFORMANCE") = py::int_(adiak_performance);
+  mod.attr("ADIAK_CATEGORY_CONTROL") = py::int_(adiak_control);
+  // Bind the custom data containers to Python.
+  // Note that we don't wrap the DataContainer base class or the 'to_adiak'
+  // methods because we don't need those exposed to Python.
+  py::class_<adiak::python::Timepoint>(mod, "Timepoint")
+      .def(py::init<std::chrono::system_clock::time_point>())
+      .def("to_python", &adiak::python::Timepoint::to_python);
+  py::class_<adiak::python::Date>(mod, "Date")
+      .def(py::init<std::chrono::system_clock::time_point>())
+      .def("to_python", &adiak::python::Timepoint::to_python);
+  py::class_<adiak::python::Version>(mod, "Version")
+      .def(py::init<const std::string &>())
+      .def("to_python", &adiak::python::Timepoint::to_python);
+  py::class_<adiak::python::Path>(mod, "Path")
+      .def(py::init<const std::string &>())
+      .def("to_python", &adiak::python::Timepoint::to_python);
+  py::class_<adiak::python::CatStr>(mod, "CatStr")
+      .def(py::init<const std::string &>())
+      .def("to_python", &adiak::python::Timepoint::to_python);
+  py::class_<adiak::python::JsonStr>(mod, "JsonStr")
+      .def(py::init<const std::string &>())
+      .def("to_python", &adiak::python::Timepoint::to_python);
+}
+
+} // namespace python
+} // namespace adiak

--- a/src/interface/python/types.hpp
+++ b/src/interface/python/types.hpp
@@ -1,0 +1,105 @@
+#ifndef ADIAK_INTERFACE_PYTHON_TYPES_HPP_
+#define ADIAK_INTERFACE_PYTHON_TYPES_HPP_
+
+#include "common.hpp"
+
+#include <chrono>
+#include <type_traits>
+
+namespace adiak {
+namespace python {
+
+// The 'is_templated_base_of' type trait is derived from the following
+// StackOverflow post:
+// https://stackoverflow.com/a/49163138
+template <template <typename...> class Base, typename Derived,
+          typename TCheck = void>
+struct is_templated_base_of_tester;
+
+template <template <typename...> class Base, typename Derived>
+struct is_templated_base_of_tester<
+    Base, Derived, std::enable_if_t<std::is_class<Derived>::value>> : Derived {
+  template <typename... T> static constexpr std::true_type test(Base<T...> *);
+  static constexpr std::false_type test(...);
+  using is_base = decltype(test((is_templated_base_of_tester *)nullptr));
+};
+
+template <template <typename...> class Base, typename Derived>
+struct is_templated_base_of_tester<
+    Base, Derived, std::enable_if_t<!std::is_class<Derived>::value>> {
+  using is_base = std::false_type;
+};
+
+template <template <typename...> class Base, typename Derived>
+using is_templated_base_of =
+    typename is_templated_base_of_tester<Base, Derived>::is_base;
+
+template <typename T, class adiak_type> struct DataContainer {
+  T m_v;
+
+  DataContainer(T val) : m_v(val) {}
+
+  virtual T to_python() const { return m_v; }
+
+  virtual adiak_type to_adiak() const = 0;
+};
+
+// Python-compatible struct for storing timepoint info
+// that will be converted into 'struct timeval' for Adiak
+struct Timepoint : public DataContainer<std::chrono::system_clock::time_point,
+                                        struct timeval *> {
+  struct timeval m_time_for_adiak;
+
+  Timepoint(std::chrono::system_clock::time_point time);
+
+  struct timeval *to_adiak() const final;
+};
+
+// Python-compatible struct for storing date or datetime info
+// that will be converted into 'adiak::date' for Adiak
+struct Date
+    : public DataContainer<std::chrono::system_clock::time_point, adiak::date> {
+  Date(std::chrono::system_clock::time_point time);
+
+  adiak::date to_adiak() const final;
+};
+
+// Python-compatible struct for storing version info
+// that will be converted into 'adiak::version' for Adiak
+struct Version : public DataContainer<std::string, adiak::version> {
+  Version(const std::string &ver);
+
+  adiak::version to_adiak() const final;
+};
+
+// TODO replace use of string with std::filesystem if/when C++17 is supported
+// Python-compatible struct for storing path info
+// that will be converted into 'adiak::path' for Adiak
+struct Path : public DataContainer<std::string, adiak::path> {
+  Path(const std::string &p);
+
+  adiak::path to_adiak() const final;
+};
+
+// Python-compatible struct for storing categorical string info
+// that will be converted into 'adiak::catstring' for Adiak
+struct CatStr : public DataContainer<std::string, adiak::catstring> {
+  CatStr(const std::string &cs);
+
+  adiak::catstring to_adiak() const final;
+};
+
+// Python-compatible struct for storing JSON string info
+// that will be converted into 'adiak::jsonstring' for Adiak
+struct JsonStr : public DataContainer<std::string, adiak::jsonstring> {
+  JsonStr(const std::string &js);
+
+  adiak::jsonstring to_adiak() const final;
+};
+
+void create_adiak_types_mod(py::module_ &mod);
+
+} // namespace python
+} // namespace adiak
+
+#endif /* ADIAK_INTERFACE_PYTHON_TYPES_HPP_ */


### PR DESCRIPTION
Follow up to Slack discussions with @michaelmckinsey1.

This PR adds Python bindings to Adiak, similar to those added to Caliper.

Like Caliper, these bindings consist of 2 parts:
1. A C++-to-Python bridge implemented with [pybind11]()
2. A small Python library that wraps the bridge code

Also similar to Caliper, these bindings are installed to `lib[64]/pythonX.Y/site-packages/pyadiak` (where "X.Y" refers to the Python version used during build).