### PR TITLE
Implement record metadata with timestamps

### DIFF
--- a/include/adiak.h
+++ b/include/adiak.h
@@ -25,6 +25,8 @@ extern "C" {
 #define ADIAK_HAVE_LONGLONG 1
 /** \brief Adiak supports jsonstring type */
 #define ADIAK_HAVE_JSONSTRING 1
+/** \brief Adiak supports timestamp values in record info */
+#define ADIAK_HAVE_TIMESTAMPS 1
 
 /**
  * \addtogroup UserAPI

--- a/include/adiak_tool.h
+++ b/include/adiak_tool.h
@@ -59,6 +59,23 @@ typedef struct adiak_record_info_t {
 typedef void (*adiak_nameval_cb_t)(const char *name, int category, const char *subcategory, adiak_value_t *value, adiak_datatype_t *t, void *opaque_value);
 
 /**
+ * \brief Callback function for processing an Adiak name/value pair including metadata
+ *
+ * This callback function is called once for each queried name/value pair. It provides
+ * name, value and record metadata such as the timestamp.
+ *
+ * \param name Name of the name/value pair
+ * \param value The value of the name/value pair. Refer to \ref adiak_value_t to see which
+ *   union value to choose based on the datatype \a t.
+ * \param t The datatype specification of the name/value pair.
+ * \param info Metadata for the name/value pair
+ * \param opaque_value Optional user-defined pass-through argument
+ *
+ * \sa adiak_register_cb, adiak_list_namevals
+ */
+typedef void (*adiak_nameval_info_cb_t)(const char *name, adiak_value_t *value, adiak_datatype_t *t, adiak_record_info_t *info, void *opaque_value);
+
+/**
  * \brief Register a callback function to be invoked when a name/value pair is set
  *
  * \param[in] adiak_version Adiak API version. Currently 1.
@@ -71,6 +88,11 @@ typedef void (*adiak_nameval_cb_t)(const char *name, int category, const char *s
  * \param[in] opaque_val User-provided value passed through to the callback function.
  */
 void adiak_register_cb(int adiak_version, int category, adiak_nameval_cb_t nv, int report_on_all_ranks, void *opaque_val);
+
+/**
+ * \copydoc adiak_register_cb
+ */
+void adiak_register_cb_with_info(int adiak_version, int category, adiak_nameval_info_cb_t nv, int report_on_all_ranks, void *opaque_val);
 
 /**
  * \brief Iterate over the name/value pairs currently registered with Adiak
@@ -86,6 +108,11 @@ void adiak_register_cb(int adiak_version, int category, adiak_nameval_cb_t nv, i
  * \param[in] opaque_val User-provided value passed through to the callback function.
  */
 void adiak_list_namevals(int adiak_version, int category, adiak_nameval_cb_t nv, void *opaque_val);
+
+/**
+ * \copydoc adiak_list_namevals
+ */
+void adiak_list_namevals_with_info(int adiak_version, int category, adiak_nameval_info_cb_t nv, void *opaque_val);
 
 /**
  * \brief Return the type string descriptor for an Adiak datatype specification
@@ -118,7 +145,7 @@ int adiak_get_nameval(const char *name, adiak_datatype_t **t, adiak_value_t **va
  * \param[out] value Value of the name/value pair
  * \param[out] info Metadata for the name/value pair
  */
-int adiak_get_nameval_info(const char* name, adiak_datatype_t **t, adiak_value_t **value, adiak_record_info_t **info);
+int adiak_get_nameval_with_info(const char* name, adiak_datatype_t **t, adiak_value_t **value, adiak_record_info_t **info);
 
 /**
  * \brief Return the number of sub-values for the given container type \a t

--- a/include/adiak_tool.h
+++ b/include/adiak_tool.h
@@ -13,6 +13,8 @@
 
 #include "adiak.h"
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -23,6 +25,21 @@ extern "C" {
  * \name Adiak tool API
  * \{
  */
+
+/**
+ * \brief Contains metadata for an adiak name/value pair
+ */
+typedef struct adiak_record_info_t {
+    /** \brief The adiak category, e.g. \ref adiak_general */
+    int category;
+    /** \brief An optional user-defined subcategory */
+    const char* subcategory;
+    /** \brief Timestamp when the value was last set
+     *
+     * In POSIX systems, this is a CLOCK_REALTIME timestamp.
+     */
+    struct timespec timestamp;
+} adiak_record_info_t;
 
 /**
  * \brief Callback function for processing an Adiak name/value pair
@@ -94,6 +111,16 @@ char *adiak_type_to_string(adiak_datatype_t *t, int long_form);
 int adiak_get_nameval(const char *name, adiak_datatype_t **t, adiak_value_t **value, int *category, const char **subcat);
 
 /**
+ * \brief Query the currently set value and info for \a name
+ *
+ * \param[in] name Name of the name/value pair to query
+ * \param[out] t Datatype specification of the name/value pair
+ * \param[out] value Value of the name/value pair
+ * \param[out] info Metadata for the name/value pair
+ */
+int adiak_get_nameval_info(const char* name, adiak_datatype_t **t, adiak_value_t **value, adiak_record_info_t **info);
+
+/**
  * \brief Return the number of sub-values for the given container type \a t
  */
 int adiak_num_subvals(adiak_datatype_t* t);
@@ -112,7 +139,7 @@ int adiak_num_subvals(adiak_datatype_t* t);
  *
  * Returns NULL in \a subtype and in \a subvalue.v_ptr if the given
  * value is not a container type or \a elem is out-of-bounds.
- * 
+ *
  * \param[in] t The container datatype
  * \param[in] val The container value
  * \param[in] elem Index of the sub-element to return

--- a/src/adiak.c
+++ b/src/adiak.c
@@ -23,6 +23,8 @@ typedef struct adiak_tool_t {
    adiak_nameval_cb_t name_val_cb;
    int report_on_all_ranks;
    int category;
+   // Below fields are present with record info
+   adiak_nameval_info_cb_t nameval_info_cb;
 } adiak_tool_t;
 
 typedef struct record_list_t {
@@ -33,7 +35,7 @@ typedef struct record_list_t {
    adiak_datatype_t *dtype;
    struct record_list_t *list_next;
    struct record_list_t *hash_next;
-   adiak_record_info_t info;
+   adiak_record_info_t *info;
 } record_list_t;
 
 typedef struct {
@@ -80,6 +82,7 @@ static adiak_datatype_t base_path_ref = { adiak_path, adiak_categorical, 0, 0, N
 static void adiak_common_init();
 static void adiak_register(int adiak_version, int category,
                            adiak_nameval_cb_t nv,
+                           adiak_nameval_info_cb_t nvi,
                            int report_on_all_ranks, void *opaque_val);
 
 static int find_end_brace(const char *typestr, char endchar, int typestr_start, int typestr_end);
@@ -94,8 +97,8 @@ static adiak_type_t toplevel_type(const char *typestr);
 static int calc_size(adiak_datatype_t *datatype);
 static int copy_value(adiak_value_t *target, adiak_datatype_t *datatype, void *ptr);
 
-static void record_nameval(const char *name, int category, const char *subcategory,
-                           adiak_value_t *value, adiak_datatype_t *dtype);
+static record_list_t* record_nameval(const char *name, int category, const char *subcategory,
+                                     adiak_value_t *value, adiak_datatype_t *dtype);
 
 static int measure_walltime();
 static int measure_systime();
@@ -120,9 +123,12 @@ int adiak_raw_namevalue(const char *name, int category, const char *subcategory,
                         adiak_value_t *value, adiak_datatype_t *type)
 {
    adiak_tool_t *tool;
+   adiak_record_info_t *info_ptr = NULL;
 
-   if (category != adiak_control)
-      record_nameval(name, category, subcategory, value, type);
+   if (category != adiak_control) {
+      record_list_t* rec = record_nameval(name, category, subcategory, value, type);
+      info_ptr = rec->info;
+   }
    if (!tool_list)
       return 0;
 
@@ -133,8 +139,19 @@ int adiak_raw_namevalue(const char *name, int category, const char *subcategory,
          continue;
       if (tool->category != adiak_category_all && tool->category != category)
          continue;
-      if (tool->name_val_cb)
+      if (tool->name_val_cb) {
          tool->name_val_cb(name, category, subcategory, value, type, tool->opaque_val);
+      } else if (tool->nameval_info_cb) {
+         adiak_record_info_t info;
+         memset(&info, 0, sizeof(adiak_record_info_t));
+         if (!info_ptr) {
+            info.category = category;
+            info.subcategory = subcategory;
+            adksys_clock_realtime(&info.timestamp);
+            info_ptr = &info;
+         }
+         tool->nameval_info_cb(name, value, type, info_ptr, tool->opaque_val);
+      }
    }
    return 0;
 }
@@ -248,7 +265,13 @@ adiak_numerical_t adiak_numerical_from_type(adiak_type_t dtype)
 void adiak_register_cb(int adiak_version, int category,
                        adiak_nameval_cb_t nv, int report_on_all_ranks, void *opaque_val)
 {
-   adiak_register(adiak_version, category, nv, report_on_all_ranks, opaque_val);
+   adiak_register(adiak_version, category, nv, NULL, report_on_all_ranks, opaque_val);
+}
+
+void adiak_register_cb_with_info(int adiak_version, int category,
+                                 adiak_nameval_info_cb_t nv, int report_on_all_ranks, void *opaque_val)
+{
+   adiak_register(adiak_version, category, NULL, nv, report_on_all_ranks, opaque_val);
 }
 
 void adiak_list_namevals(int adiak_version, int category, adiak_nameval_cb_t nv, void *opaque_val)
@@ -259,6 +282,18 @@ void adiak_list_namevals(int adiak_version, int category, adiak_nameval_cb_t nv,
       if (category != adiak_category_all && i->category != category)
          continue;
       nv(i->name, i->category, i->subcategory, i->value, i->dtype, opaque_val);
+   }
+   (void) adiak_version;
+}
+
+void adiak_list_namevals_with_info(int adiak_version, int category, adiak_nameval_info_cb_t nv, void *opaque_val)
+{
+   record_list_t *i;
+   adiak_common_init();
+   for (i = adiak_config->shared_record_list; i != NULL; i = i->list_next) {
+      if (category != adiak_category_all && i->category != category)
+         continue;
+      nv(i->name, i->value, i->dtype, i->info, opaque_val);
    }
    (void) adiak_version;
 }
@@ -283,7 +318,7 @@ int adiak_get_nameval(const char *name, adiak_datatype_t **t, adiak_value_t **va
    return -1;
 }
 
-int adiak_get_nameval_info(const char *name, adiak_datatype_t **t, adiak_value_t **value,  adiak_record_info_t **info)
+int adiak_get_nameval_with_info(const char *name, adiak_datatype_t **t, adiak_value_t **value,  adiak_record_info_t **info)
 {
    record_list_t *i;
    adiak_common_init();
@@ -294,7 +329,7 @@ int adiak_get_nameval_info(const char *name, adiak_datatype_t **t, adiak_value_t
          if (value)
             *value = i->value;
          if (info)
-            *info = &i->info;
+            *info = i->info;
          return 0;
       }
    }
@@ -450,6 +485,7 @@ void adiak_fini()
 
 static void adiak_register(int adiak_version, int category,
                            adiak_nameval_cb_t nv,
+                           adiak_nameval_info_cb_t nvi,
                            int report_on_all_ranks, void *opaque_val)
 {
    adiak_tool_t *newtool;
@@ -460,6 +496,7 @@ static void adiak_register(int adiak_version, int category,
    newtool->opaque_val = opaque_val;
    newtool->report_on_all_ranks = report_on_all_ranks;
    newtool->name_val_cb = nv;
+   newtool->nameval_info_cb = nvi;
    newtool->category = category;
    newtool->next = (adiak_tool_t *) *tool_list;
    newtool->prev = NULL;
@@ -907,8 +944,8 @@ static unsigned long strhash(const char *str) {
     return hash;
 }
 
-static void record_nameval(const char *name, int category, const char *subcategory,
-                           adiak_value_t *value, adiak_datatype_t *dtype)
+static record_list_t* record_nameval(const char *name, int category, const char *subcategory,
+                                     adiak_value_t *value, adiak_datatype_t *dtype)
 {
    record_list_t *addrecord = NULL, *i;
    unsigned long hashval;
@@ -930,6 +967,7 @@ static void record_nameval(const char *name, int category, const char *subcatego
       free_adiak_value(addrecord->dtype, addrecord->value);
       free_adiak_type(addrecord->dtype);
       free((void*) addrecord->subcategory);
+      free((void*) addrecord->info);
       addrecord->subcategory = NULL;
    }
 
@@ -938,12 +976,16 @@ static void record_nameval(const char *name, int category, const char *subcatego
    addrecord->value = value;
    addrecord->dtype = dtype;
 
-   addrecord->info.category = category;
-   addrecord->info.subcategory = addrecord->subcategory;
-   adksys_clock_realtime(&addrecord->info.timestamp);
+   adiak_record_info_t* info = malloc(sizeof(adiak_record_info_t));
+   memset(info, 0, sizeof(adiak_record_info_t));
+
+   info->category = category;
+   info->subcategory = addrecord->subcategory;
+   adksys_clock_realtime(&info->timestamp);
+   addrecord->info = info;
 
    if (!newrecord)
-      return;
+      return addrecord;
 
    addrecord->name = (const char *) strdup(name);
 
@@ -954,6 +996,8 @@ static void record_nameval(const char *name, int category, const char *subcatego
 
    addrecord->hash_next = record_hash[hashval];
    record_hash[hashval] = addrecord;
+
+   return addrecord;
 }
 
 int adiak_flush(const char *location)
@@ -977,6 +1021,7 @@ int adiak_clean()
       free_adiak_value(i->dtype, i->value);
       free_adiak_type(i->dtype);
       free((void *) i->name);
+      free((void *) i->info);
       if (i->subcategory)
          free((void *) i->subcategory);
       next = i->list_next;

--- a/src/adksys.h
+++ b/src/adksys.h
@@ -7,6 +7,7 @@
 #define ADKSYS_H_
 
 #include <sys/time.h> /* struct timeval */
+#include <time.h>
 
 int adksys_get_libraries(char ***libraries, int *libraries_size, int *libnames_need_free);
 int adksys_hostlist(char ***out_hostlist_array, int *out_num_hosts, char **out_name_buffer, int all_ranks);
@@ -15,6 +16,7 @@ int adksys_reportable_rank();
 int adksys_mpi_init(void *mpi_communicator_p);
 int adksys_get_times(struct timeval *sys, struct timeval *cpu);
 int adksys_curtime(struct timeval *tm);
+int adksys_clock_realtime(struct timespec* ts);
 int adksys_hostname(char *outbuffer, int buffer_size);
 int adksys_starttime(struct timeval *tv);
 int adksys_get_executable(char *outpath, size_t outpath_size);

--- a/src/adksys_posix.c
+++ b/src/adksys_posix.c
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+#define _XOPEN_SOURCE 600
 #include <sys/times.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -43,6 +44,10 @@ int adksys_get_times(struct timeval *sys, struct timeval *cpu)
 
 int adksys_curtime(struct timeval *tm) {
    return gettimeofday(tm, NULL);
+}
+
+int adksys_clock_realtime(struct timespec *ts) {
+   return clock_gettime(CLOCK_REALTIME, ts);
 }
 
 int adksys_hostname(char *outbuffer, int buffer_size)

--- a/tests/test_application-api.cpp
+++ b/tests/test_application-api.cpp
@@ -175,7 +175,7 @@ TEST(AdiakApplicationAPI, C_BasicTypes)
     adiak_datatype_t* subtype = nullptr;
     adiak_record_info_t* info = nullptr;
 
-    EXPECT_EQ(adiak_get_nameval_info("c:int", &dtype, &val, &info), 0);
+    EXPECT_EQ(adiak_get_nameval_with_info("c:int", &dtype, &val, &info), 0);
     EXPECT_EQ(dtype->dtype, adiak_type_t::adiak_int);
     EXPECT_EQ(val->v_int, -42);
     EXPECT_EQ(info->category, adiak_general);

--- a/tests/test_application-api.cpp
+++ b/tests/test_application-api.cpp
@@ -145,8 +145,15 @@ TEST(AdiakApplicationAPI, CXX_CompoundTypes)
     EXPECT_EQ(inner_subval.v_int, 3);
 }
 
+bool operator < (const struct timespec& a, const struct timespec& b)
+{
+    return a.tv_sec < b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec < b.tv_nsec);
+}
+
 TEST(AdiakApplicationAPI, C_BasicTypes)
 {
+    struct timespec ts_0, ts_1;
+    clock_gettime(CLOCK_REALTIME, &ts_0);
     EXPECT_EQ(adiak_namevalue("c:int", adiak_general, NULL, "%d", -42), 0);
     EXPECT_EQ(adiak_namevalue("c:uint", adiak_general, NULL, "%u", 42u), 0);
     EXPECT_EQ(adiak_namevalue("c:int64", adiak_general, NULL, "%lld", 9876543210ll), 0);
@@ -155,6 +162,7 @@ TEST(AdiakApplicationAPI, C_BasicTypes)
     EXPECT_EQ(adiak_namevalue("c:path", adiak_general, NULL, "%p", "/a/b/c"), 0);
     EXPECT_EQ(adiak_namevalue("c:catstring", adiak_general, NULL, "%r", "cat"), 0);
     EXPECT_EQ(adiak_namevalue("c:json", adiak_general, NULL, "%j", "{ \"json\": true }"), 0);
+    clock_gettime(CLOCK_REALTIME, &ts_1);
 
     const int test_cat = 4242;
     EXPECT_EQ(adiak_namevalue("c:new_category", test_cat, "subcat:c", "%d", 42), 0);
@@ -165,13 +173,16 @@ TEST(AdiakApplicationAPI, C_BasicTypes)
     const char* subcat = nullptr;
     adiak_value_t subval;
     adiak_datatype_t* subtype = nullptr;
+    adiak_record_info_t* info = nullptr;
 
-    EXPECT_EQ(adiak_get_nameval("c:int", &dtype, &val, &cat, &subcat), 0);
+    EXPECT_EQ(adiak_get_nameval_info("c:int", &dtype, &val, &info), 0);
     EXPECT_EQ(dtype->dtype, adiak_type_t::adiak_int);
     EXPECT_EQ(val->v_int, -42);
-    EXPECT_EQ(cat, adiak_general);
+    EXPECT_EQ(info->category, adiak_general);
     EXPECT_EQ(adiak_num_subvals(dtype), 0);
     EXPECT_EQ(adiak_get_subval(dtype, val, 0, &subtype, &subval), -1);
+    EXPECT_LT(ts_0, info->timestamp);
+    EXPECT_LT(info->timestamp, ts_1);
 
     EXPECT_EQ(adiak_get_nameval("c:uint", &dtype, &val, nullptr, nullptr), 0);
     EXPECT_EQ(dtype->dtype, adiak_type_t::adiak_uint);

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -138,9 +138,10 @@ static void print_value(adiak_value_t *val, adiak_datatype_t *t)
    }
 }
 
-static void print_nameval(const char *name, int UNUSED(category), const char *UNUSED(subcategory), adiak_value_t *value, adiak_datatype_t *t, void *UNUSED(opaque_value))
+static void print_nameval(const char *name, adiak_value_t *value, adiak_datatype_t *t, adiak_record_info_t *info, void *UNUSED(opaque_value))
 {
-   printf("%s - %s: ", STR(TOOLNAME), name);
+   double timestamp = ((double) info->timestamp.tv_sec) + (info->timestamp.tv_nsec * 1e-9);
+   printf("%s - %f - %s: ", STR(TOOLNAME), timestamp, name);
    print_value(value, t);
    printf("\n");
 }
@@ -149,7 +150,7 @@ static void print_on_flush(const char *name, int UNUSED(category), const char *U
 {
    if (strcmp(name, "flush") != 0)
       return;
-   adiak_list_namevals(1, adiak_category_all, print_nameval, NULL);
+   adiak_list_namevals_with_info(1, adiak_category_all, print_nameval, NULL);
 }
 
 
@@ -159,7 +160,5 @@ static void onload()
    if (strcmp(STR(TOOLNAME), "TOOL3") == 0)
       adiak_register_cb(1, adiak_control, print_on_flush, 0, NULL);
    else
-      adiak_register_cb(1, adiak_category_all, print_nameval, 0, NULL);
+      adiak_register_cb_with_info(1, adiak_category_all, print_nameval, 0, NULL);
 }
-
-


### PR DESCRIPTION
Adds metadata info to Adiak name/value pairs with timestamps. Addresses #36. Also adds a new set of tool calls to retrieve the metadata info.