### PR TITLE
Fix testapp-cxx printing

### DIFF
--- a/tests/testapp.cpp
+++ b/tests/testapp.cpp
@@ -115,6 +115,14 @@ void dowork(struct timeval
    if (!result) printf("return: %d\n\n", result);
 }
 
+/* Somehow the testlib constructor doesn't work in the C++ app
+   so we just call the print function directly.
+ */
+extern "C"
+{
+void print_all_adiak_vars();
+}
+
 int main(
 #if defined(USE_MPI)
   int argc, char *argv[]
@@ -137,6 +145,7 @@ int main(
 #endif
 
    dowork(start);
+   print_all_adiak_vars();
 
    adiak::fini();
    adiak::clean();

--- a/tests/testlib.c
+++ b/tests/testlib.c
@@ -156,6 +156,10 @@ static void print_on_flush(const char *name, int UNUSED(category), const char *U
    adiak_list_namevals_with_info(1, adiak_category_all, print_nameval, NULL);
 }
 
+void print_all_adiak_vars()
+{
+   adiak_list_namevals_with_info(1, adiak_category_all, print_nameval, NULL);
+}
 
 static void onload() __attribute__((constructor));
 static void onload()


### PR DESCRIPTION
Somehow the C++ test app doesn't load the `testlib.c` tool constructor. We now call the print function manually.